### PR TITLE
Collections Update 2023-02-15

### DIFF
--- a/_data/collections.yml
+++ b/_data/collections.yml
@@ -1,4 +1,4 @@
-- name: Rolling Stone 500
+- name: "Rolling Stone: Greatest Albums"
   description: >-
     The 500 Greatest Albums of All Time is a list of the best rock and pop albums from the 1950s to the 2000s, as decided by an international panel of music critics and industry experts. It was originally published in 2003 and updated in 2012. The list is presented in the book Rolling Stone's 500 Greatest Albums of All Time and an updated version was published in 2020.
   article_url: https://www.rollingstone.com/music/music-lists/best-albums-of-all-time-1062063/
@@ -15,4 +15,9 @@
   url: https://longplay.rocks/data/collections/NY100J.json
   count: 100
   date: 2008-05-19
+- name: "Rolling Stone: Concept Albums"
+  article_url: https://www.rollingstone.com/music/music-lists/best-concept-albums-1234604040/the-roots-20-1234604517/
+  url: https://longplay.rocks/data/collections/RS50CO.json
+  count: 100
+  date: 2022-10-12
   

--- a/_data/collections.yml
+++ b/_data/collections.yml
@@ -16,7 +16,7 @@
   count: 100
   date: 2008-05-19
 - name: "Rolling Stone: Concept Albums"
-  article_url: https://www.rollingstone.com/music/music-lists/best-concept-albums-1234604040/the-roots-20-1234604517/
+  article_url: https://www.rollingstone.com/music/music-lists/best-concept-albums-1234604040/
   url: https://longplay.rocks/data/collections/RS50CO.json
   count: 100
   date: 2022-10-12

--- a/data/collections/BB100C.json
+++ b/data/collections/BB100C.json
@@ -1,6 +1,6 @@
 {
-    "name": "Billboard: The 100 Best Album Covers of All Time",
-    "article_url": "https:\/\/www.billboard.com\/photos\/best-album-covers-of-all-time-6715351\/32-14-blink-182-enema-of-the-state-1999-album-art-billboard-1240\/",
+    "name": "Billboard: Album Covers",
+    "article_url": "https:\/\/www.billboard.com\/photos\/best-album-covers-of-all-time-6715351",
     "albums": [
         {
             "rank": 1,

--- a/data/collections/NY100J.json
+++ b/data/collections/NY100J.json
@@ -1,5 +1,5 @@
 {
-    "name": "The New Yorker: 100 Essential Jazz Albums",
+    "name": "The New Yorker: Essential Jazz",
     "article_url": "https:\/\/www.newyorker.com\/magazine\/2008\/05\/19\/100-essential-jazz-albums",
     "albums": [
         {

--- a/data/collections/RS500.json
+++ b/data/collections/RS500.json
@@ -1,6 +1,6 @@
 {
     "name": "Rolling Stone Top 500",
-    "article_url": "https://www.rollingstone.com/music/music-lists/best-albums-of-all-time-1062063/",
+    "article_url": "https:\/\/www.rollingstone.com\/music\/music-lists\/best-albums-of-all-time-1062063\/",
     "albums": [
         {
             "rank": 1,
@@ -9,7 +9,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/whats-going-on\/1538081586",
             "appleMusicID": "1538081586",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-001-Marvin-Gaye-WHATS-GOING-ON.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/76\/36\/2d\/76362d74-cb7a-8ef9-104e-cde1d858e9a9\/20UMGIM95279.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 2,
@@ -18,7 +18,7 @@
             "year": 1966,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pet-sounds\/1440841241",
             "appleMusicID": "1440841241",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-002-Beach-Boys-PET-SOUNDS-update.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/35\/bb\/c4\/35bbc4eb-9387-97b0-b138-64b7a949ea43\/13UABIM03512.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 3,
@@ -27,7 +27,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blue\/1492263092",
             "appleMusicID": "1492263092",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-003-JoniMitchell-BLUE-HR.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/00\/a2\/43\/00a24363-cf69-bfd2-a26a-a042d57ab141\/075992719926.jpg\/600x600bb.jpg"
         },
         {
             "rank": 4,
@@ -36,7 +36,7 @@
             "year": 1976,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/songs-in-the-key-of-life\/1440788438",
             "appleMusicID": "1440788438",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-004-Stevie-Wonder-SONGS-IN-THE-KEY-OF-LIFE.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/eb\/1f\/12\/eb1f12ec-474c-63aa-43af-09282f423b9d\/00602537004737.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 5,
@@ -45,7 +45,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/abbey-road-remastered\/1441164426",
             "appleMusicID": "1441164426",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-005-Beatles-ABBEY-ROAD.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/df\/db\/61\/dfdb615d-47f8-06e9-9533-b96daccc029f\/18UMGIM31076.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 6,
@@ -54,7 +54,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/nevermind\/1440783617",
             "appleMusicID": "1440783617",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-006-Nirvana-NEVERMIND-HR.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/95\/fd\/b9\/95fdb9b2-6d2b-92a6-97f2-51c1a6d77f1a\/00602527874609.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 7,
@@ -63,7 +63,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rumours-deluxe-edition\/651871544",
             "appleMusicID": "651871544",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-007-Fleetwood-Mac-RUMOURS.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/dd\/77\/35\/dd773533-06a7-4566-bef4-2c43c24d08f6\/603497925759.jpg\/600x600bb.jpg"
         },
         {
             "rank": 8,
@@ -72,7 +72,7 @@
             "year": 1984,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/purple-rain\/214145442",
             "appleMusicID": "214145442",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-008-Prince-PURPLE-RAIN.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/b7\/44\/ca\/b744ca9b-9b29-e934-3d59-5da099a83ce3\/mzi.shgvhklf.jpg\/600x600bb.jpg"
         },
         {
             "rank": 9,
@@ -81,7 +81,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blood-on-the-tracks\/158320766",
             "appleMusicID": "158320766",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-009-Bob-Dylan-BLOOD-ON-THE-TRACKS.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/34\/6e\/4d\/346e4d1c-c9ef-cf7f-96d9-aad97286febb\/074643323529.jpg\/600x600bb.jpg"
         },
         {
             "rank": 10,
@@ -90,7 +90,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-miseducation-of-lauryn-hill\/1276760743",
             "appleMusicID": "1276760743",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-010-Lauryn-Hill-MISEDUCATION.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/09\/6b\/55\/096b55c4-ee8f-23bd-df8f-0ca0821f3028\/886446727189.jpg\/600x600bb.jpg"
         },
         {
             "rank": 11,
@@ -99,25 +99,25 @@
             "year": 1966,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/revolver-2022-mix\/1642995371",
             "appleMusicID": "1642995371",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-011-BeatlesREVOLVER-updated.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/30\/8e\/f2\/308ef249-a27b-0320-4ea4-ed8d938501c0\/22UMGIM95893.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 12,
             "artist": "Michael Jackson",
             "album": "Thriller",
             "year": 1982,
-            "appleMusicURL": "https:\/\/music.apple.com\/album\/thriller\/269572838?i=269573303&l=en-GB",
+            "appleMusicURL": "https:\/\/music.apple.com\/album\/thriller\/269572838",
             "appleMusicID": "269572838",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-012-MichaelJacksonThriller.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/32\/4f\/fd\/324ffda2-9e51-8f6a-0c2d-c6fd2b41ac55\/074643811224.jpg\/600x600bb.jpg"
         },
         {
             "rank": 13,
             "artist": "Aretha Franklin",
             "album": "I Never Loved a Man the Way I Love You",
             "year": 1967,
-            "appleMusicURL": "https:\/\/music.apple.com\/album\/i-never-loved-a-man-the-way-i-love-you\/937107826?i=937107841&l=en-GB",
+            "appleMusicURL": "https:\/\/music.apple.com\/album\/i-never-loved-a-man-the-way-i-love-you\/937107826",
             "appleMusicID": "937107826",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-013-ArethaFrankNEVERLOVED-H.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/d1\/31\/ee\/d131eec4-614c-d661-b580-3dc32b8547e8\/603497896622.jpg\/600x600bb.jpg"
         },
         {
             "rank": 14,
@@ -126,7 +126,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/exile-on-main-st-2010-remaster\/1440872228",
             "appleMusicID": "1440872228",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-014-Rolling-Stones-EXILE-ON-MAIN-ST.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/b6\/7b\/df\/b67bdff8-4e30-d46d-e869-fc0f38462f4c\/08UMGIM15728.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 15,
@@ -135,16 +135,16 @@
             "year": 1988,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/it-takes-a-nation-of-millions-to-hold-us-back\/1440837788",
             "appleMusicID": "1440837788",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-015-Public-Enemy-IT-TAKES-A-NATION-H.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/80\/be\/7c\/80be7c4f-f2e8-a40e-f9ab-86a8c4ef1535\/00602547742315.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 16,
             "artist": "The Clash",
             "album": "London Calling",
             "year": 1979,
-            "appleMusicURL": "https:\/\/music.apple.com\/album\/london-calling\/684811762?i=684811768&l=en-GB",
+            "appleMusicURL": "https:\/\/music.apple.com\/album\/london-calling\/684811762",
             "appleMusicID": "684811762",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/016-Clash-LONDON-CALLING.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/45\/d7\/17\/45d71740-b204-de23-3f9e-f2f823296f1d\/886443520721.jpg\/600x600bb.jpg"
         },
         {
             "rank": 17,
@@ -153,16 +153,16 @@
             "year": 2010,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/my-beautiful-dark-twisted-fantasy-deluxe-edition-explicit\/1440621197",
             "appleMusicID": "1440621197",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-017-Kanye-My-Beautiful-Dark-Twisted-Fantasy.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/79\/36\/4f\/79364f95-df81-e427-f989-86ae4df1c3b9\/10UMGIM30072.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 18,
             "artist": "Bob Dylan",
             "album": "Highway 61 Revisited",
             "year": 1965,
-            "appleMusicURL": "https:\/\/music.apple.com\/album\/highway-61-revisited\/201281514?i=201283479&l=en-GB",
+            "appleMusicURL": "https:\/\/music.apple.com\/album\/highway-61-revisited\/201281514",
             "appleMusicID": "201281514",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-018-Bob-Dylan-HWY-61-REVISITED-updated.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/f8\/ff\/c0\/f8ffc056-55b4-2033-657d-32492d1eea25\/827969239926.jpg\/600x600bb.jpg"
         },
         {
             "rank": 19,
@@ -171,7 +171,7 @@
             "year": 2015,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/to-pimp-a-butterfly\/1440828886",
             "appleMusicID": "1440828886",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-019-Kendrick-Lamar-To-Pimp-a-Butterfly.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/0d\/ae\/61\/0dae6140-d4af-d0df-eae0-3c92eb392a33\/15UMGIM11922.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 20,
@@ -180,16 +180,16 @@
             "year": 2000,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/kid-a\/1097862870",
             "appleMusicID": "1097862870",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-020-Radiohead-KID-A.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/bd\/8e\/13\/bd8e1358-b367-a689-cb84-cebd0b067dc4\/634904078263.png\/600x600bb.jpg"
         },
         {
             "rank": 21,
             "artist": "Bruce Springsteen",
             "album": "Born to Run",
             "year": 1975,
-            "appleMusicURL": "https:\/\/music.apple.com\/album\/born-to-run\/310730204?i=310730214&l=en-GB",
+            "appleMusicURL": "https:\/\/music.apple.com\/album\/born-to-run\/310730204",
             "appleMusicID": "310730204",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-021-Bruce-Springsteen-BORN-TO-RUN.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/0a\/02\/f7\/0a02f7a1-ca2a-c0d7-7192-50314971721f\/884977157031.jpg\/600x600bb.jpg"
         },
         {
             "rank": 22,
@@ -198,7 +198,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ready-to-die-the-remaster\/204669326",
             "appleMusicID": "204669326",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-022-notorious-BIG-ready-to-die.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features125\/v4\/bb\/ac\/73\/bbac7336-a1b4-9111-31cd-0daeb278fcc8\/dj.hjzzaivb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 23,
@@ -207,7 +207,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-velvet-underground-nico-45th-anniversary-edition\/1440851613",
             "appleMusicID": "1440851613",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-023-Velvet-Underground-VU_N.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/92\/93\/39\/9293397f-a707-237e-ec7e-0ca613a67e3c\/06UMGIM04143.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 24,
@@ -216,7 +216,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sgt-peppers-lonely-hearts-club-band-remix\/1573250333",
             "appleMusicID": "1573250333",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-024-BeatlesSGTPeppersLonley-updated.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/64\/85\/d2\/6485d219-91ac-5481-2668-7eab1320436d\/21UMGIM57007.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 25,
@@ -225,7 +225,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/tapestry\/747087657",
             "appleMusicID": "747087657",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-025-Carole-King-TAPESTRY.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/68\/b6\/0e\/68b60e89-9d41-e8a1-bba2-05c750f0832b\/dj.hwpyamqm.jpg\/600x600bb.jpg"
         },
         {
             "rank": 26,
@@ -234,7 +234,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/horses\/1038568061",
             "appleMusicID": "1038568061",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-026-Patti-Smith-HORSES.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/61\/85\/d5\/6185d59b-047a-a184-3fb4-60a3851cef43\/886445500394.jpg\/600x600bb.jpg"
         },
         {
             "rank": 27,
@@ -243,7 +243,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/enter-the-wu-tang-36-chambers-expanded-edition\/269842381",
             "appleMusicID": "269842381",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-027-Wu-Tang-Clan-ENTER-THE-WU.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/54\/d3\/cd\/54d3cd0a-109f-930b-8fee-0acf35e81754\/dj.brdcktik.jpg\/600x600bb.jpg"
         },
         {
             "rank": 28,
@@ -252,7 +252,7 @@
             "year": 2000,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/voodoo\/1440841365",
             "appleMusicID": "1440841365",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-028-D_Angelo-Voodoo.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/fd\/be\/cd\/fdbecdf2-5bf5-09fc-8fab-6e93250ebda4\/13ULAIM54464.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 29,
@@ -261,7 +261,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-beatles-the-white-album\/1441133180",
             "appleMusicID": "1441133180",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-029-Beatles-WHITE-ALBUM.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/fa\/5b\/89\/fa5b898d-bad6-e053-4195-260e5c74f2bb\/00602567725466.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 30,
@@ -270,7 +270,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/are-you-experienced-deluxe-version\/359540012",
             "appleMusicID": "359540012",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-030-Jimi-Hendrix-Exp-ARE-YOU-EXPERIENCED.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/b3\/92\/68\/b3926862-8ab0-f14d-23db-7c6987a6c068\/mzi.tokjqusn.jpg\/600x600bb.jpg"
         },
         {
             "rank": 31,
@@ -279,7 +279,7 @@
             "year": 1959,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/kind-of-blue\/268443092",
             "appleMusicID": "268443092",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-031-Miles-Davis-KIND-OF-BLUE.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/7f\/9f\/d6\/mzi.vtnaewef.jpg\/600x600bb.jpg"
         },
         {
             "rank": 32,
@@ -288,7 +288,7 @@
             "year": 2016,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/lemonade\/1460430561",
             "appleMusicID": "1460430561",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-032-Beyonce-Lemonade.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/db\/25\/a1\/db25a1c0-8a4a-3b4d-226d-7c7704dc92da\/886447680711.jpg\/600x600bb.jpg"
         },
         {
             "rank": 33,
@@ -297,7 +297,7 @@
             "year": 2006,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/back-to-black\/1422677780",
             "appleMusicID": "1422677780",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-033-Amy-Winehouse-Back-to-Black.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/5a\/72\/3f\/5a723fec-965d-3483-89f8-d66b79f88419\/15UMGIM24224.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 34,
@@ -306,7 +306,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/innervisions\/1440806790",
             "appleMusicID": "1440806790",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-034-Stevie-Wonder-Innervisions.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/ff\/c2\/5f\/ffc25f04-cb3b-b56e-dd28-8b77ae63e613\/00602537070824.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 35,
@@ -315,7 +315,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rubber-soul\/1441164359",
             "appleMusicID": "1441164359",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-035-The-Beatles-Rubber-Soul.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/af\/20\/aa\/af20aa89-4002-11fb-25d8-ff544af67eb4\/00602567725404.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 36,
@@ -324,7 +324,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/off-the-wall\/186166282",
             "appleMusicID": "186166282",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-036-Michael-Jackson-Off-The-Wall.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/cc\/b0\/7f\/ccb07f0d-1530-00b0-244a-6332daffc2b9\/dj.xnuhftrz.jpg\/600x600bb.jpg"
         },
         {
             "rank": 37,
@@ -333,7 +333,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-chronic\/1668460963",
             "appleMusicID": "1668460963",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-037-dr-dre-the-chronic.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/22\/55\/6c\/22556ce7-92fb-3a7a-af98-33b0e4bed0d8\/23UMGIM07603.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 38,
@@ -342,7 +342,7 @@
             "year": 1966,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blonde-on-blonde\/178049863",
             "appleMusicID": "178049863",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-038-Bob-Dylan-Blonde-on-Blonde.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/20\/9d\/bf\/209dbf58-f698-7181-33de-0c29480beba0\/074640084126.jpg\/600x600bb.jpg"
         },
         {
             "rank": 39,
@@ -351,7 +351,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/remain-in-light\/300948043",
             "appleMusicID": "300948043",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-039-talking-heads-remain-in-light.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/87\/5f\/5b\/mzi.zzquknhm.jpg\/600x600bb.jpg"
         },
         {
             "rank": 40,
@@ -360,7 +360,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-rise-and-fall-of-ziggy-stardust-and-the\/1039796877",
             "appleMusicID": "1039796877",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-040-David-Bowie-The-Rise-and-Fall-of-Ziggy-Stardust.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/5f\/fa\/56\/5ffa56c2-ea1f-7a17-6bad-192ff9b6476d\/825646124206.jpg\/600x600bb.jpg"
         },
         {
             "rank": 41,
@@ -369,7 +369,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/let-it-bleed-remastered\/1500642838",
             "appleMusicID": "1500642838",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-041-The-Rolling-Stones-Let-It-Bleed.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/69\/64\/67\/696467fe-9ed1-b65e-1016-a10d07e6464d\/20UMGIM14087.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 42,
@@ -378,7 +378,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ok-computer-oknotok-1997-2017\/1239489060",
             "appleMusicID": "1239489060",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-042-Radiohead-OK-Computer.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/9c\/f5\/04\/9cf50453-c311-5324-ffe3-805a811efd73\/dj.besjjjpd.jpg\/600x600bb.jpg"
         },
         {
             "rank": 43,
@@ -387,7 +387,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-low-end-theory\/278911460",
             "appleMusicID": "278911460",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-043-A-Tribe-Called-Quest-The-Low-End-Theory.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e0\/14\/c8\/e014c80a-425b-e01a-1124-cee985bcb5e6\/dj.qafpkddz.jpg\/600x600bb.jpg"
         },
         {
             "rank": 44,
@@ -396,7 +396,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/illmatic\/662324135",
             "appleMusicID": "662324135",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-044-Nas-Illmatic.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/e8\/13\/50\/e813500d-51cd-6c37-c405-53a668cbde97\/886444072496.jpg\/600x600bb.jpg"
         },
         {
             "rank": 45,
@@ -405,7 +405,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sign-o-the-times\/212852926",
             "appleMusicID": "212852926",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-045-Prince-Sign-O-the-Times.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/a3\/b8\/f0\/a3b8f034-e5cb-336a-4a79-1c782aca4224\/075992557726.jpg\/600x600bb.jpg"
         },
         {
             "rank": 46,
@@ -414,7 +414,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/graceland\/529574560",
             "appleMusicID": "529574560",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-046-Paul-Simon-Graceland.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/a7\/73\/c1\/a773c1f0-281c-324c-204f-540444080ea8\/886443445697.jpg\/600x600bb.jpg"
         },
         {
             "rank": 47,
@@ -423,7 +423,7 @@
             "year": 1976,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ramones\/847972873",
             "appleMusicID": "847972873",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-047-Ramones-Ramones.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/v4\/eb\/c0\/ab\/ebc0ab80-e4df-08fd-64fd-e3c464e6c607\/603497909629.jpg\/600x600bb.jpg"
         },
         {
             "rank": 48,
@@ -432,7 +432,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/exodus-2013-remaster\/1625213430",
             "appleMusicID": "1625213430",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-071-bob-marley-and-the-wailers-exodus.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/23\/fa\/f8\/23faf820-c4fa-2bf1-d672-846971f5cf5c\/06UMGIM31355.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 49,
@@ -441,7 +441,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/aquemini\/266365274",
             "appleMusicID": "266365274",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-049-Outkast-Aquemini.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/09\/d1\/dc\/09d1dccf-7ff4-02b6-9613-942a6d140452\/730082605328.jpg\/600x600bb.jpg"
         },
         {
             "rank": 50,
@@ -450,7 +450,7 @@
             "year": 2001,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-blueprint\/1440757381",
             "appleMusicID": "1440757381",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-050-Jay-Z-The-Blueprint.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/8f\/a6\/d4\/8fa6d4ea-3953-f208-dd35-0d14b9fb0e03\/07UMGIM02256.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 51,
@@ -459,7 +459,7 @@
             "year": 1982,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-great-twenty-eight\/1425250670",
             "appleMusicID": "1425250670",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-051-Chuck-Berry-The-Great-Twenty-Eight.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/0d\/af\/7e\/0daf7e8b-c3f1-5d94-4685-cacffc232082\/12UMGIM50166.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 52,
@@ -468,7 +468,7 @@
             "year": 1976,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/station-to-station-2016-remaster\/1195104858",
             "appleMusicID": "1195104858",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-052-David-Bowie-Station-to-Station.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/91\/d8\/47\/91d847ac-8e39-85b0-36a6-ab3b8db46803\/190295990268.jpg\/600x600bb.jpg"
         },
         {
             "rank": 53,
@@ -477,7 +477,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/electric-ladyland\/357652252",
             "appleMusicID": "357652252",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-053-Jimi-Hendrix-Electric-Ladyland.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/a6\/b8\/45\/a6b84589-6ff7-a462-9ff9-170b724980d5\/dj.wjkdwlks.jpg\/600x600bb.jpg"
         },
         {
             "rank": 54,
@@ -486,7 +486,7 @@
             "year": 1991,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-054-James-Brown-Star-Time.jpg"
+            "imageURL": null
         },
         {
             "rank": 55,
@@ -495,7 +495,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-dark-side-of-the-moon-2011-remastered\/700016575",
             "appleMusicID": "700016575",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-055-Pink-Floyd-Dark-Side-of-the-Moon.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features124\/v4\/ba\/87\/dd\/ba87ddde-41b8-cb44-3675-61a2ba920e36\/dj.nobsviqs.jpg\/600x600bb.jpg"
         },
         {
             "rank": 56,
@@ -504,7 +504,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/exile-in-guyville-2018-remaster\/1589236833",
             "appleMusicID": "1589236833",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-056-Liz-Phair-Exile-in-Guyville.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/f0\/96\/e6\/f096e697-a41a-2ec3-e48e-754b4f85aada\/744861111450.png\/600x600bb.jpg"
         },
         {
             "rank": 57,
@@ -513,7 +513,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-band-remastered\/1440846597",
             "appleMusicID": "1440846597",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-057-The-Band-The-Band.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/ca\/b2\/06\/cab20688-46b7-e7be-c64a-dbbeeb2fc864\/15UMGIM06558.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 58,
@@ -522,7 +522,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/led-zeppelin-iv-remastered\/580708175",
             "appleMusicID": "580708175",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-058-Led-Zeppelin-IV.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/5c\/15\/9b\/5c159b27-95ca-b9a7-84e3-28e795fffd39\/dj.kvkrpptq.jpg\/600x600bb.jpg"
         },
         {
             "rank": 59,
@@ -531,7 +531,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/talking-book\/1440808973",
             "appleMusicID": "1440808973",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-059-Stevie-Wonder-Talking-Book.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/62\/61\/61\/626161c0-f4d7-e6ff-8586-768340ef278f\/00602537002382.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 60,
@@ -540,7 +540,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/astral-weeks\/1031002336",
             "appleMusicID": "1031002336",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-060-Van-Morrison-Astral-Weeks.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/88\/91\/1b\/88911b7b-a63f-4624-3fb1-2976b628c59a\/603497886340.jpg\/600x600bb.jpg"
         },
         {
             "rank": 61,
@@ -549,7 +549,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/paid-in-full\/1440841577",
             "appleMusicID": "1440841577",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-061-Eric-B-Rakim-Paid-In-Full.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/13\/11\/10\/13111001-0c28-9fd7-9d50-194e72e23f53\/00602547742254.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 62,
@@ -558,7 +558,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/appetite-for-destruction\/1377813284",
             "appleMusicID": "1377813284",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-062-Guns-N-Roses-Appetite-for-Destruction.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/a0\/4d\/c4\/a04dc484-03cc-02aa-fa82-5334fcb4bc16\/18UMGIM24878.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 63,
@@ -567,16 +567,16 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/aja\/1706428459",
             "appleMusicID": "1706428459",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-063-steely-dan-aja.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/c2\/3c\/54\/c23c5414-20d1-7aea-f0f5-187974c58d65\/23UMGIM79990.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 64,
             "artist": "OutKast",
             "album": "Stankonia",
             "year": 2000,
-            "appleMusicURL": "https:\/\/music.apple.com\/album\/ms-jackson\/255836651?i=255836745&l=en-GB",
+            "appleMusicURL": "https:\/\/music.apple.com\/album\/ms-jackson\/255836651",
             "appleMusicID": "255836651",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-064-outkast-stankonia.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/e0\/4c\/f4\/e04cf460-46a5-992a-87c7-2c1aef7e3a46\/730082607223.jpg\/600x600bb.jpg"
         },
         {
             "rank": 65,
@@ -585,7 +585,7 @@
             "year": 1963,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/live-at-the-apollo-1962\/1445669062",
             "appleMusicID": "1445669062",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-065-James-Brown-Live-at-the-Apollo.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/e7\/41\/db\/e741dbd4-3795-8eef-969c-546ff7c5b1a8\/00602537429806.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 66,
@@ -594,7 +594,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/a-love-supreme\/1440713018",
             "appleMusicID": "1440713018",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-066-John-Coltrane-A-Love-Supreme.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/e5\/24\/aa\/e524aacd-467b-66f3-8931-0fcd6750a4b9\/08UMGIM07914.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 67,
@@ -603,7 +603,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/reasonable-doubt\/1636373860",
             "appleMusicID": "1636373860",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-067-Jay-Z-Reasonable-Doubt.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/1a\/46\/10\/1a461001-637a-8438-3722-6100ebaad434\/1549.jpg\/600x600bb.jpg"
         },
         {
             "rank": 68,
@@ -612,7 +612,7 @@
             "year": 1985,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/hounds-of-love-2018-remaster\/1675560565",
             "appleMusicID": "1675560565",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-068-Kate-Bush-Hounds-of-Love.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/62\/97\/32\/62973286-5bb3-0de7-c051-8b2de8d95472\/cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 69,
@@ -621,7 +621,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/jagged-little-pill-collectors-edition\/1031419290",
             "appleMusicID": "1031419290",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-069-Alanis-Morissette-Jagged-Little-Pill.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music4\/v4\/4d\/04\/71\/4d0471a5-3bd6-2c5b-a438-3568fcd70e1c\/603497885510.jpg\/600x600bb.jpg"
         },
         {
             "rank": 70,
@@ -630,7 +630,7 @@
             "year": 1988,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/straight-outta-compton\/1440816032",
             "appleMusicID": "1440816032",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-070-nwa-straight-outta-compton.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e3\/82\/52\/e38252e8-148d-551e-2216-4b51e847f1bd\/00602547276506.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 71,
@@ -639,7 +639,7 @@
             "year": 2022,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/renaissance\/1630005298",
             "appleMusicID": "1630005298",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2022\/11\/Beyonce-Renaissance.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/05\/05\/f3\/0505f338-9873-feb4-af7f-27a470405e5f\/196589246974.jpg\/600x600bb.jpg"
         },
         {
             "rank": 72,
@@ -648,7 +648,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/harvest\/1015739190",
             "appleMusicID": "1015739190",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-072-Neil-Young-HARVEST.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e0\/4b\/c4\/e04bc4e6-9d3a-0bab-c953-f139c72fd337\/093624924722.jpg\/600x600bb.jpg"
         },
         {
             "rank": 73,
@@ -657,7 +657,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/loveless\/1556921230",
             "appleMusicID": "1556921230",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-073-My-Bloody-Valentine-Loveless.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/d8\/9c\/a2\/d89ca2ad-3191-d877-4c2f-13fb3e619a7b\/887830015998.png\/600x600bb.jpg"
         },
         {
             "rank": 74,
@@ -666,7 +666,7 @@
             "year": 2004,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-college-dropout\/1412872568",
             "appleMusicID": "1412872568",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-074-Kanye-West-The-College-Dropout.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/0d\/73\/b1\/0d73b181-2716-f7a6-a340-0a3f81eacfb9\/06UMGIM15686.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 75,
@@ -675,7 +675,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/lady-soul\/933585548",
             "appleMusicID": "933585548",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-075-Aretha-Franklin-Lady-Soul.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e3\/a7\/ac\/e3a7aca0-48e1-0882-8e25-3d68f7ba3a72\/603497896646.jpg\/600x600bb.jpg"
         },
         {
             "rank": 76,
@@ -684,7 +684,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/superfly-soundtrack-from-the-motion-picture\/1048472205",
             "appleMusicID": "1048472205",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-076-Curtis-Mayfield-Superfly.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/c4\/34\/f0\/c434f094-4c7e-3c62-8f15-cd02028e1ce7\/603497885978.jpg\/600x600bb.jpg"
         },
         {
             "rank": 77,
@@ -693,7 +693,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/whos-next-remastered-2022\/1706357665",
             "appleMusicID": "1706357665",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-077-The-Who-Who_s-Next.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/a5\/e7\/70\/a5e7703c-4e30-da7a-a319-2d3caef42c0e\/23UM1IM04872.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 78,
@@ -702,7 +702,7 @@
             "year": 1976,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-078-Elvis-Presley.-The-Sun-Sessions.jpg"
+            "imageURL": null
         },
         {
             "rank": 79,
@@ -711,7 +711,7 @@
             "year": 2016,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blonde\/1146195596",
             "appleMusicID": "1146195596",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-079-Frank-Ocean-Blonde.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/bb\/45\/68\/bb4568f3-68cd-619d-fbcb-4e179916545d\/BlondCover-Final.jpg\/600x600bb.jpg"
         },
         {
             "rank": 80,
@@ -720,7 +720,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/never-mind-the-bollocks-heres-the-sex-pistols\/1443347631",
             "appleMusicID": "1443347631",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-080-The-Sex-Pistols-Nevermind-the-Bollocks-Heres-the-Sex-Pistols.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/bb\/55\/fd\/bb55fdde-11dc-3d59-a969-802ebaea1a6a\/00602557878837.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 81,
@@ -729,7 +729,7 @@
             "year": 2013,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/beyonc\u00e9-platinum-edition\/939775882",
             "appleMusicID": "939775882",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-081-Beyonce-Beyonce.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/cb\/d0\/1b\/cbd01b16-7759-38ec-15a2-8a98228319ff\/886444935265.jpg\/600x600bb.jpg"
         },
         {
             "rank": 82,
@@ -738,7 +738,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/theres-a-riot-goin-on-expanded-edition\/216546634",
             "appleMusicID": "216546634",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-082-Sly-and-the-Family-Stone-Theres-a-Riot-Goin-On.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/91\/01\/9f\/91019f68-fbc9-5620-d49a-88043d75371e\/828767591124.jpg\/600x600bb.jpg"
         },
         {
             "rank": 83,
@@ -747,7 +747,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/dusty-in-memphis-remastered-deluxe-edition\/1440717710",
             "appleMusicID": "1440717710",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-083-Dusty-Springfield-Dusty-in-Memphis.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/4d\/8b\/6e\/4d8b6e4e-4424-693b-a1d5-6d1d53d944d0\/00044006329727.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 84,
@@ -756,7 +756,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/back-in-black\/574050396",
             "appleMusicID": "574050396",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-084-AC_DC-Back-in-Black.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/1e\/14\/58\/1e145814-281a-58e0-3ab1-145f5d1af421\/886443673441.jpg\/600x600bb.jpg"
         },
         {
             "rank": 85,
@@ -765,7 +765,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/john-lennon-plastic-ono-band-the-ultimate-mixes\/1556019890",
             "appleMusicID": "1556019890",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-085-John-Lennon-Plastic-Ono-Band.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/c4\/3e\/ec\/c43eec3c-fcba-6108-4451-2a68914e2249\/20UMGIM52435.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 86,
@@ -774,7 +774,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-doors\/1622368510",
             "appleMusicID": "1622368510",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-086-The-Doors-The-Doors.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/97\/e2\/ce\/97e2ce16-02e1-54f6-3896-dcc55249ff7d\/603497838738.jpg\/600x600bb.jpg"
         },
         {
             "rank": 87,
@@ -783,7 +783,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/bitches-brew\/168376392",
             "appleMusicID": "168376392",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-087-Miles-Davis-Bitches-Brew.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/9b\/e1\/63\/9be1630c-486d-760c-76cf-04282174700a\/074646577424.jpg\/600x600bb.jpg"
         },
         {
             "rank": 88,
@@ -792,7 +792,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/hunky-dory-2015-remaster\/1039798000",
             "appleMusicID": "1039798000",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-088-david-bowie-hunky-dory.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/f0\/b9\/68\/f0b9680e-b028-b3d6-f793-7c268256499a\/825646286034.jpg\/600x600bb.jpg"
         },
         {
             "rank": 89,
@@ -801,7 +801,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/baduizm-special-edition\/1452803889",
             "appleMusicID": "1452803889",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-089-Erykah-Badu-Baduizm.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/45\/39\/54\/453954b7-d99d-625c-9c49-6b4f5d228ae7\/07UMGIM09528.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 90,
@@ -810,7 +810,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/after-the-gold-rush\/1015783330",
             "appleMusicID": "1015783330",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-090-Neil-Young-After-the-Gold-Rush.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/88\/9f\/0a\/889f0afc-ca89-5968-ef83-ab07f7184eb6\/093624924753.jpg\/600x600bb.jpg"
         },
         {
             "rank": 91,
@@ -819,7 +819,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/darkness-on-the-edge-of-town-paramount-theater\/1532536856",
             "appleMusicID": "1532536856",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-091-bruce-springsteen-darkness-on-the-edge-of-town.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/fe\/4d\/a6\/fe4da6a1-2e23-19fb-e74f-62e9598ab580\/886448738381.jpg\/600x600bb.jpg"
         },
         {
             "rank": 92,
@@ -828,7 +828,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/axis-bold-as-love\/357222341",
             "appleMusicID": "357222341",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-092-Jimi-Hendrix-Experience-axis-bold-as-love.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/93\/5d\/c5\/935dc5d5-a985-333d-0825-879ddb36e461\/884977526585.jpg\/600x600bb.jpg"
         },
         {
             "rank": 93,
@@ -837,7 +837,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/supa-dupa-fly\/302943429",
             "appleMusicID": "302943429",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-093-Missy-Misdemeanor-Elliott-Supa-Dupa-Fly.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/b5\/1a\/e3\/mzi.gjotvoax.jpg\/600x600bb.jpg"
         },
         {
             "rank": 94,
@@ -846,7 +846,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/funhouse\/843836692",
             "appleMusicID": "843836692",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-094-the-stooges-funhouse.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music6\/v4\/ea\/84\/3c\/ea843cdb-04ca-63c1-dd30-ddf3a0b94ca9\/075596066921.jpg\/600x600bb.jpg"
         },
         {
             "rank": 95,
@@ -855,7 +855,7 @@
             "year": 2011,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/take-care-deluxe-version\/1440642493",
             "appleMusicID": "1440642493",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-095-Drake-Take-Care.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/74\/fb\/d3\/74fbd365-bd52-23b4-604b-7f164407b0a9\/00602527899107.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 96,
@@ -864,7 +864,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/automatic-for-the-people-2017-remaster\/1571670285",
             "appleMusicID": "1571670285",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-096-R.E.M.-Automatic-for-the-People.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/38\/ae\/cc\/38aecc92-1d12-2437-5fb2-1cb78bce3afe\/21CRGIM28685.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 97,
@@ -873,7 +873,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/master-of-puppets-remastered\/1440901428",
             "appleMusicID": "1440901428",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-097-metallica-master-of-puppets.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/82\/9a\/c0\/829ac046-9ef9-b027-3257-c2ed6a515707\/17UM1IM18688.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 98,
@@ -882,7 +882,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/car-wheels-on-a-gravel-road\/1440915686",
             "appleMusicID": "1440915686",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-098-Lucinda-Williams-Car-Wheels-On-A-Gravel-Road.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/7b\/3a\/55\/7b3a5503-e015-2074-7aeb-c93c745b4cb7\/06UMGIM05369.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 99,
@@ -891,7 +891,7 @@
             "year": 2012,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/red-deluxe-version\/1440873509",
             "appleMusicID": "1440873509",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-099-Taylor-Swift-Red.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/f1\/cf\/9a\/f1cf9a28-afff-b156-22b8-2b3a2d2daa25\/00602537223695.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 100,
@@ -900,7 +900,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/music-from-big-pink-remastered-2000\/1440814725",
             "appleMusicID": "1440814725",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-100-The-Band-Music-From-Big-Pink.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/44\/eb\/9f\/44eb9ffc-8e77-9a3d-8be7-8ca579de93cc\/13UACIM30926.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 101,
@@ -909,7 +909,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/led-zeppelin-remastered\/580708520",
             "appleMusicID": "580708520",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-101-Led-Zeppelin-Led-Zeppelin.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/4c\/7b\/80\/4c7b80b4-ed35-4e06-ec80-2f7aaaabb5c5\/dj.pjjmtwdc.jpg\/600x600bb.jpg"
         },
         {
             "rank": 102,
@@ -918,7 +918,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-clash-2013-remastered\/684737755",
             "appleMusicID": "684737755",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-102-The-Clash-The-Clash.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/53\/8d\/7f\/538d7f34-71e3-df2d-5221-4df922ab9510\/886443520738.jpg\/600x600bb.jpg"
         },
         {
             "rank": 103,
@@ -927,7 +927,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/3-feet-high-and-rising\/1657705063",
             "appleMusicID": "1657705063",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-103-de-la-soul-3-feet-high-and-rising.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/13\/1e\/c3\/131ec37d-d764-51a6-c800-ace81490e20d\/810098502627.png\/600x600bb.jpg"
         },
         {
             "rank": 104,
@@ -936,7 +936,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sticky-fingers-2015-remaster\/1440812661",
             "appleMusicID": "1440812661",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-104-The-Rolling-Stones-Sticky-Fingers.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/7f\/e0\/b4\/7fe0b4da-36cd-a1d0-0f19-ef3fec18e3cd\/08UMGIM15742.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 105,
@@ -945,7 +945,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/at-fillmore-east-deluxe-edition-live\/1444531900",
             "appleMusicID": "1444531900",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-105-The-Allman-Brothers-At-Fillmore-East.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/78\/7a\/92\/787a929d-abd8-ca82-f908-c3509aabdc24\/06UMGIM10914.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 106,
@@ -954,7 +954,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/live-through-this\/1445732603",
             "appleMusicID": "1445732603",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-106-Hole-Live-Through-This.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/9b\/3a\/17\/9b3a172c-e3d8-044d-77e4-6b1096b5a093\/00720642463123.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 107,
@@ -963,7 +963,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/marquee-moon\/1049069472",
             "appleMusicID": "1049069472",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-107-television-marquee-moon.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/1b\/6a\/c1\/1b6ac100-8d0e-ec9d-4639-88b11ed2cdad\/603497886029.jpg\/600x600bb.jpg"
         },
         {
             "rank": 108,
@@ -972,7 +972,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/when-the-pawn-hits-the-conflicts-he-thinks-like-a-king\/153019510",
             "appleMusicID": "153019510",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-108-Fiona-Apple-When-the-Pawn.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/4a\/75\/0e\/4a750e5f-ad9e-2801-885f-40cb36596397\/mzi.eyhxnmkd.jpg\/600x600bb.jpg"
         },
         {
             "rank": 109,
@@ -981,7 +981,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/transformer\/976826793",
             "appleMusicID": "976826793",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-109-lou-reed-transformer.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/2a\/e7\/69\/2ae76967-b94e-3b80-a079-93202eeb6157\/886445151930.jpg\/600x600bb.jpg"
         },
         {
             "rank": 110,
@@ -990,7 +990,7 @@
             "year": 1974,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/court-and-spark-2022-remaster\/1653407741",
             "appleMusicID": "1653407741",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-110-joni-mitchell-court-and-spark.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/41\/dc\/bc\/41dcbcc4-115b-7c60-cc8e-a1c1011d9d2a\/603497833450.jpg\/600x600bb.jpg"
         },
         {
             "rank": 111,
@@ -999,7 +999,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/control\/1440831636",
             "appleMusicID": "1440831636",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-111-Janet-Jackson-Control.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/ed\/b0\/20\/edb02000-b77f-22f4-6b7f-c46f62d4517c\/00602547592361.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 112,
@@ -1008,7 +1008,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/goodbye-yellow-brick-road-2014-remaster\/1440863013",
             "appleMusicID": "1440863013",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-112-Elton-John-Goodbye-Yellow-Brick-Road.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/b3\/60\/b6\/b360b655-4d28-179d-d0d4-4e128ebdf4c9\/13UAEIM19273.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 113,
@@ -1017,7 +1017,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-queen-is-dead\/800092985",
             "appleMusicID": "800092985",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-113-The-Smiths-The-Queen-Is-Dead.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/1a\/e8\/70\/1ae870c3-b402-096b-c4c4-8022af5a2ed9\/745099189662.jpg\/600x600bb.jpg"
         },
         {
             "rank": 114,
@@ -1026,7 +1026,7 @@
             "year": 2001,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/is-this-it\/269080434",
             "appleMusicID": "269080434",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-114-The-Strokes-Is-This-It.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features115\/v4\/b3\/32\/4a\/b3324ab7-77df-c200-9a30-62db4fce0b57\/dj.nizobaay.jpg\/600x600bb.jpg"
         },
         {
             "rank": 115,
@@ -1035,7 +1035,7 @@
             "year": 2012,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/good-kid-m-a-a-d-city-deluxe\/1440873524",
             "appleMusicID": "1440873524",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-115-Kendrick-Lamar-Good-Kid-Maad-City.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/ba\/c3\/c5\/bac3c531-dc7e-d0da-d785-fe9f17219950\/12UMGIM52990.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 116,
@@ -1044,7 +1044,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/disintegration-deluxe-edition\/1440984569",
             "appleMusicID": "1440984569",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-116-CureDISINTEGRATION-HR.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/63\/da\/f0\/63daf0e3-bda1-8b37-8a58-55a0fb0e947b\/00600753270134.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 117,
@@ -1053,7 +1053,7 @@
             "year": 2005,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/late-registration\/1440668749",
             "appleMusicID": "1440668749",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-117-Kanye-West-Late-Registration.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/00\/68\/13\/006813b3-9ca1-2e6f-98df-4ef78cd6cb49\/06UMGIM20452.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 118,
@@ -1062,7 +1062,7 @@
             "year": 1976,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/hotel-california\/635770200",
             "appleMusicID": "635770200",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-118-The-Eagles-Hotel-California.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/88\/16\/2c\/88162c3d-46db-8321-61f3-3a47404cfe76\/075596050920.jpg\/600x600bb.jpg"
         },
         {
             "rank": 119,
@@ -1071,7 +1071,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/stand-bonus-tracks-edition-2007-remaster\/216551517",
             "appleMusicID": "216551517",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-119-Sly-and-The-Family-Stone-Stand.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/ba\/2e\/c3\/ba2ec374-39ac-1bf7-f64e-63c8b215484b\/828767591223.jpg\/600x600bb.jpg"
         },
         {
             "rank": 120,
@@ -1080,7 +1080,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/moondance\/712727450",
             "appleMusicID": "712727450",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-120-Van-Morrison-Moondance.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/9a\/c7\/e2\/9ac7e266-1f0d-997a-fe43-6741bc96eda6\/081227963637.jpg\/600x600bb.jpg"
         },
         {
             "rank": 121,
@@ -1089,7 +1089,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/this-years-model-2021-remaster-deluxe\/1585423236",
             "appleMusicID": "1585423236",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-121-Elvis-Costello-This-Years-Model.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/3b\/40\/80\/3b40808e-986c-7b03-d337-1c9ee850b45e\/21UMGIM48777.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 122,
@@ -1098,7 +1098,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-downward-spiral\/1440837096",
             "appleMusicID": "1440837096",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-122-nin-downward-spiral.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/55\/e0\/85\/55e0851e-11df-3b6a-7c54-4eef0efc2bed\/15UMGIM67680.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 123,
@@ -1107,7 +1107,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/led-zeppelin-ii-remastered\/580708374",
             "appleMusicID": "580708374",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-123-Led-Zeppelin-II.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/1a\/3d\/bb\/1a3dbb86-c1f8-737e-571f-d6b647a230be\/dj.rhubuvkd.jpg\/600x600bb.jpg"
         },
         {
             "rank": 124,
@@ -1116,7 +1116,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/achtung-baby\/1443063058",
             "appleMusicID": "1443063058",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-124-U2-ACHTUNG-BABY-HR.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/fe\/5e\/4f\/fe5e4f79-c74f-c39e-39dc-4c8a952b9665\/17UMGIM98829.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 125,
@@ -1125,7 +1125,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pauls-boutique-20th-anniversary-remastered-edition\/721276795",
             "appleMusicID": "721276795",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-125-Beastie-Boys-pauls-boutique.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/bf\/b9\/82\/bfb9825b-e130-0664-2f2f-3a766a1161c6\/05099969330056.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 126,
@@ -1134,7 +1134,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/my-life-deluxe-commentary-edition\/1498277732",
             "appleMusicID": "1498277732",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-126-Mary-J-Blige-My-Life.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/cc\/cb\/70\/cccb705b-ce73-4b6f-7f74-d3575561fa13\/20UMGIM03203.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 127,
@@ -1143,7 +1143,7 @@
             "year": 1962,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/modern-sounds-in-country-and-western-music-vols-1-2\/1477684012",
             "appleMusicID": "1477684012",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-127-ray-charles-modern-sounds.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/16\/d6\/06\/16d6065d-f751-d1ae-c5f4-ae9e5489e4cd\/19CRGIM11655.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 128,
@@ -1152,7 +1152,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/a-night-at-the-opera\/1440854433",
             "appleMusicID": "1440854433",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-128-Queen-A-Night-at-the-Opera.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/a8\/71\/eb\/a871ebc7-4a5a-2d7d-3963-b1302930e321\/14UMGIM39390.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 129,
@@ -1161,7 +1161,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-wall\/704273346",
             "appleMusicID": "704273346",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-129-Pink-Floyd-the-Wall.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features124\/v4\/aa\/88\/2c\/aa882ccd-d153-9901-8ee1-c246e5b704b3\/dj.esjczuop.jpg\/600x600bb.jpg"
         },
         {
             "rank": 130,
@@ -1170,7 +1170,7 @@
             "year": 1982,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/1999-super-deluxe-edition\/1479565271",
             "appleMusicID": "1479565271",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-130-prince-1999.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/e7\/5a\/be\/e75abe7a-c363-18b4-8c40-9eb2a35cd26b\/603497850044.jpg\/600x600bb.jpg"
         },
         {
             "rank": 131,
@@ -1179,7 +1179,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/dummy\/1440653096",
             "appleMusicID": "1440653096",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-131-Portishead-Dummy.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/c1\/71\/93\/c1719342-df7d-e9c5-c87c-53dae5afb289\/00042282855329.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 132,
@@ -1188,7 +1188,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/40-greatest-hits\/1434905254",
             "appleMusicID": "1434905254",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-132-hank-williams-40-greatest-hits.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/f6\/4b\/e0\/f64be098-4f51-cf46-0ef2-64de1f3ad8e2\/06UMGIM15743.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 133,
@@ -1197,7 +1197,7 @@
             "year": 1976,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/hejira\/1492262288",
             "appleMusicID": "1492262288",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-133-Joni-Mitchell-Hejira.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/38\/42\/0b\/38420bcf-f3aa-ba5b-2594-d9b3db6bb637\/075596061421.jpg\/600x600bb.jpg"
         },
         {
             "rank": 134,
@@ -1206,7 +1206,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-score\/281701670",
             "appleMusicID": "281701670",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-134-Fugees-The-Score.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/c3\/66\/3f\/c3663fe2-5c90-f701-93f8-54d5b56bc1df\/888880608932.jpg\/600x600bb.jpg"
         },
         {
             "rank": 135,
@@ -1215,7 +1215,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-joshua-tree\/1443155637",
             "appleMusicID": "1443155637",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-135-U2-joshua-tree.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/8f\/e2\/c3\/8fe2c384-f6cb-9af7-371d-2b6a9b204e59\/17UMGIM79292.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 136,
@@ -1224,7 +1224,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/maggot-brain\/1595227414",
             "appleMusicID": "1595227414",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-136-Funkadelic-Maggot-Brain.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/c4\/19\/49\/c4194943-0b41-5987-b2e8-193b74ea70ed\/artwork.jpg\/600x600bb.jpg"
         },
         {
             "rank": 137,
@@ -1233,7 +1233,7 @@
             "year": 2011,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/21\/403037872",
             "appleMusicID": "403037872",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-137-Adele-21.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/ba\/53\/61\/ba536163-de06-6640-32d2-70d28ff1ae12\/634904152062.png\/600x600bb.jpg"
         },
         {
             "rank": 138,
@@ -1242,7 +1242,7 @@
             "year": 1990,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-immaculate-collection\/80812428",
             "appleMusicID": "80812428",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-138-Madonna-The-Immaculate-Collection.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features114\/v4\/32\/fd\/6e\/32fd6e25-da2b-10e9-df38-2923c01b6c9b\/dj.jaxugjvp.jpg\/600x600bb.jpg"
         },
         {
             "rank": 139,
@@ -1251,7 +1251,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/paranoid\/1533659667",
             "appleMusicID": "1533659667",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-180-black-sabbath-paranoid.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/93\/74\/16\/93741672-cedb-1850-dcd9-113a374336d6\/4050538642872.jpg\/600x600bb.jpg"
         },
         {
             "rank": 140,
@@ -1260,7 +1260,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/catch-a-fire-remastered-2013\/1423269033",
             "appleMusicID": "1423269033",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-140-bob-marley-and-the-wailers-catch-a-fire.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/25\/b3\/cd\/25b3cd5f-2e29-8c3f-68ed-677786a7d55a\/06UMGIM06492.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 141,
@@ -1269,7 +1269,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/doolittle\/7060469",
             "appleMusicID": "7060469",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-141-Pixies-Doolittle.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/f8\/80\/17\/f8801798-6f7f-fa2a-446e-729a8b46e7ab\/5014436905025.png\/600x600bb.jpg"
         },
         {
             "rank": 142,
@@ -1278,7 +1278,7 @@
             "year": 1984,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/born-in-the-u-s-a\/203708420",
             "appleMusicID": "203708420",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-142-Bruce-Springsteen-Born-in-the-USA.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/32\/72\/68\/327268ba-b9dd-b322-2a16-bdd0212df48c\/074643865326.jpg\/600x600bb.jpg"
         },
         {
             "rank": 143,
@@ -1287,7 +1287,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-velvet-underground-nico-45th-anniversary-edition\/1440851613",
             "appleMusicID": "1440851613",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-143-The-Velvet-Underground-The-Velvet-Underground.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/92\/93\/39\/9293397f-a707-237e-ec7e-0ca613a67e3c\/06UMGIM04143.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 144,
@@ -1296,7 +1296,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/physical-graffiti-remastered\/580707980",
             "appleMusicID": "580707980",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-144-Led-Zeppelin-Physical-Graffiti.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/82\/6c\/5d\/826c5d66-67b7-62f2-4d78-dd3c7b415e08\/dj.pifhrvpa.jpg\/600x600bb.jpg"
         },
         {
             "rank": 145,
@@ -1305,7 +1305,7 @@
             "year": 2000,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-marshall-mathers-lp\/1453737727",
             "appleMusicID": "1453737727",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-145-Eminem-The-Marshall-Mathers-LP.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/ab\/db\/fb\/abdbfb01-acea-210c-b7a4-8160ebabfe5a\/00602577527685.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 146,
@@ -1314,7 +1314,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/parallel-lines\/1440929735",
             "appleMusicID": "1440929735",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-146-blondie-parallel-lines.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/2f\/0b\/25\/2f0b252d-838e-4f19-3c08-91e49b269564\/15UMGIM18445.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 147,
@@ -1323,7 +1323,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/grace-legacy-edition\/1476889347",
             "appleMusicID": "1476889347",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-147-Jeff-Buckley-Grace.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/99\/d6\/ab\/99d6abb0-4837-f397-3f56-c7dfd627e23e\/886447700778.jpg\/600x600bb.jpg"
         },
         {
             "rank": 148,
@@ -1332,7 +1332,7 @@
             "year": 2012,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/channel-orange\/1440765580",
             "appleMusicID": "1440765580",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-148-Frank-Ocean-Channel-Orange.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/04\/f8\/63\/04f863fc-2852-604f-c910-a97ac069506b\/12UMGIM40339.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 149,
@@ -1341,7 +1341,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/john-prine\/1018524551",
             "appleMusicID": "1018524551",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-149-John-Prine-John-Prine.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music1\/v4\/70\/1f\/ec\/701fec1e-e9c0-6f34-9d0e-43eca7ae1e6a\/603497887583.jpg\/600x600bb.jpg"
         },
         {
             "rank": 150,
@@ -1350,7 +1350,7 @@
             "year": 1982,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/nebraska\/185798980",
             "appleMusicID": "185798980",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-150-Bruce-Springsteen-Nebraska.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/76\/2d\/e5\/762de50e-0967-4d24-c4da-752164312cd2\/074643835824.jpg\/600x600bb.jpg"
         },
         {
             "rank": 151,
@@ -1359,7 +1359,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/faith-2010-remastered\/395918916",
             "appleMusicID": "395918916",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-151-George-Michael-Faith.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/87\/29\/d2\/8729d243-f06f-e588-3ddf-ffa87a2ce17e\/mzi.yupygcca.jpg\/600x600bb.jpg"
         },
         {
             "rank": 152,
@@ -1368,7 +1368,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pretenders\/118127946",
             "appleMusicID": "118127946",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-152-The-Pretenders-Pretenders.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features124\/v4\/09\/1f\/d5\/091fd520-95e3-21fb-7bda-73526bbddfce\/dj.qpjdinqa.jpg\/600x600bb.jpg"
         },
         {
             "rank": 153,
@@ -1377,7 +1377,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rid-of-me\/1440923277",
             "appleMusicID": "1440923277",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-153-PJ-Harvey-Rid-of-Me.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/27\/62\/47\/276247bf-c8c4-8590-47c2-48b053c0c62a\/00731451469626.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 154,
@@ -1386,7 +1386,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/amazing-grace-live-at-new-temple-missionary-baptist\/1628093959",
             "appleMusicID": "1628093959",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-154-Aretha-Franklin-Amazing-Grace.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/59\/fc\/3d\/59fc3ded-16c3-69b2-0ce7-b3192221b312\/603497837397.jpg\/600x600bb.jpg"
         },
         {
             "rank": 155,
@@ -1395,7 +1395,7 @@
             "year": 2003,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-black-album\/1440715885",
             "appleMusicID": "1440715885",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-155-Jay-Z-The-Black-Album.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/4d\/17\/0a\/4d170af8-2e3c-5438-e073-4db44d55bade\/06UMGIM10167.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 156,
@@ -1404,7 +1404,7 @@
             "year": 1984,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/let-it-be\/162563989",
             "appleMusicID": "162563989",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-156-The-Replacements-Let-it-Be.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/0c\/a6\/08\/0ca6088a-2080-af21-ff00-89d00a718d7a\/mzi.rxizoyov.jpg\/600x600bb.jpg"
         },
         {
             "rank": 157,
@@ -1413,7 +1413,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/whats-the-story-morning-glory-deluxe-remastered-edition\/1525933483",
             "appleMusicID": "1525933483",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-157-Oasis-What_s-the-Story-Morning-Glory.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/34\/2e\/cb\/342ecb17-ef19-816a-4ce5-e60b9ceec161\/5051961073164.jpg\/600x600bb.jpg"
         },
         {
             "rank": 158,
@@ -1422,7 +1422,7 @@
             "year": 2000,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/mamas-gun\/1440755899",
             "appleMusicID": "1440755899",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-158-Erykah-Badu-Mama_s-Gun.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/63\/9c\/05\/639c0568-e961-2146-f4cb-819a1f9226d3\/06UMGIM01547.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 159,
@@ -1431,7 +1431,7 @@
             "year": 1983,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/synchronicity-remastered-2003\/1440673959",
             "appleMusicID": "1440673959",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-159-The-Police-Synchronicity.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/a4\/67\/ba\/a467ba62-87df-9d10-98d2-c517f68ac870\/16UMGIM60882.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 160,
@@ -1440,7 +1440,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ten\/425465247",
             "appleMusicID": "425465247",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-160-Pearl-Jam-Ten.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/5e\/91\/c1\/5e91c1ba-53cb-c5c8-15f1-d3c81f3b3592\/dj.psrqglcw.jpg\/600x600bb.jpg"
         },
         {
             "rank": 161,
@@ -1449,7 +1449,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/crosby-stills-nash\/908303090",
             "appleMusicID": "908303090",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-161-Crosby-Stills-_-Nash-Crosby-Stills-and-Nash.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/a0\/ad\/8a\/a0ad8a5f-6805-b41a-c076-ee1f779d2a42\/603497928323.jpg\/600x600bb.jpg"
         },
         {
             "rank": 162,
@@ -1458,7 +1458,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/different-class\/1440923838",
             "appleMusicID": "1440923838",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-162-Pulp-Different-Class.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/a7\/4c\/c7\/a74cc719-a64b-66f7-c8c4-ee3a23b40037\/00731452416520.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 163,
@@ -1467,7 +1467,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/saturday-night-fever-the-original-movie-soundtrack\/1445668458",
             "appleMusicID": "1445668458",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-163-beegees-saturday-night-fever.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/74\/c1\/73\/74c17380-b75d-4d74-31d8-99f8e8b20c36\/17UM1IM27905.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 164,
@@ -1476,7 +1476,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/at-folsom-prison-live\/825516828",
             "appleMusicID": "825516828",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-164-Johnny-Cash-At-Folsom-Prison.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/f3\/75\/c1\/f375c1d8-9666-0119-c54b-f06e9759da5b\/886444492690.jpg\/600x600bb.jpg"
         },
         {
             "rank": 165,
@@ -1485,7 +1485,7 @@
             "year": 1983,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/murmur\/1440872981",
             "appleMusicID": "1440872981",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-165-REM-murmur.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/6c\/e2\/c3\/6ce2c349-4169-df92-e5ca-2faba4cf087f\/09UMGIM13824.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 166,
@@ -1494,7 +1494,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/20-golden-greats-buddy-holly-lives\/1425246912",
             "appleMusicID": "1425246912",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-166-Buddy-Holly-20-Golden-Hits.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/70\/ee\/e8\/70eee867-fbec-35fd-d231-a97fcb595020\/00602567833178.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 167,
@@ -1503,7 +1503,7 @@
             "year": 1990,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/violator-deluxe\/1174246686",
             "appleMusicID": "1174246686",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-167-Depeche-Mode-Violator.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/5c\/0e\/66\/5c0e66c0-d383-5641-3ec0-4bdb629c49ad\/886445705119.jpg\/600x600bb.jpg"
         },
         {
             "rank": 168,
@@ -1512,7 +1512,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/cant-buy-a-thrill\/1650885288",
             "appleMusicID": "1650885288",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-168-Steely-Dan-Cant-Buy-a-Thrill.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/08\/f3\/f1\/08f3f17c-e92a-516f-57c0-0a5d250c6cdc\/22UM1IM01200.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 169,
@@ -1521,7 +1521,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-stranger\/158617952",
             "appleMusicID": "158617952",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-169-Billy-Joel-The-Stranger.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/37\/68\/4c\/37684c52-dbdf-9bfe-0d87-07492f43dc4c\/dj.gmcbwich.jpg\/600x600bb.jpg"
         },
         {
             "rank": 170,
@@ -1530,7 +1530,7 @@
             "year": 2020,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/folklore-deluxe-version\/1528112358",
             "appleMusicID": "1528112358",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/12\/taylor-swift-folklore.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/b5\/80\/dc\/b580dca0-349d-036b-e09b-bd849f6affd8\/20UMGIM64216.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 171,
@@ -1539,7 +1539,7 @@
             "year": 1988,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/daydream-nation-remastered\/520504308",
             "appleMusicID": "520504308",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-171-Sonic-Youth-Daydream-Nation.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features125\/v4\/8a\/0c\/c3\/8a0cc364-2b35-1313-330d-7d9f686ef17d\/contsched.wjpvswwx.tif\/600x600bb.jpg"
         },
         {
             "rank": 172,
@@ -1548,7 +1548,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/bridge-over-troubled-water\/324127933",
             "appleMusicID": "324127933",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-172-Simon-and-Garfunkel-Bridge-Over-Troubled-Water.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/a3\/84\/0a\/a3840a6d-44e8-0afe-fc3e-316c517dddfe\/5099749521421.jpg\/600x600bb.jpg"
         },
         {
             "rank": 173,
@@ -1557,7 +1557,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/in-utero-20th-anniversary-edition\/1440858699",
             "appleMusicID": "1440858699",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-173-Nirvana-In-Utero.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/e3\/20\/03\/e32003a4-99bc-1c70-40ba-001882f35dba\/00602537526840.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 174,
@@ -1566,7 +1566,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-harder-they-come-original-motion-picture-soundtrack\/1535475638",
             "appleMusicID": "1535475638",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-174-jimmy-cliff-the-harder-they-come.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/ee\/fe\/57\/eefe5722-cca2-ba78-c3c0-fca085c55651\/20UMGIM71814.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 175,
@@ -1575,7 +1575,7 @@
             "year": 2017,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/damn\/1440881047",
             "appleMusicID": "1440881047",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-175-Kendrick-Lamar-Damn.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/86\/c9\/bb\/86c9bb30-fe3d-442e-33c1-c106c4d23705\/17UMGIM88776.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 176,
@@ -1584,7 +1584,7 @@
             "year": 1990,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/fear-of-a-black-planet\/1440837282",
             "appleMusicID": "1440837282",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-176-Public-Enemy-Fear-of-a-Black-Planet.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/53\/61\/ff\/5361ffae-6a48-0441-f0c8-72b587b9b494\/00602547742292.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 177,
@@ -1593,7 +1593,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/every-picture-tells-a-story\/1469580609",
             "appleMusicID": "1469580609",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-177-rod-stewart-every-picture-tells-a-story.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/7d\/4f\/20\/7d4f200e-7b9f-1240-74ee-0fbb9a30c178\/12UMGIM10698.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 178,
@@ -1602,7 +1602,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/otis-blue-mono\/922351495",
             "appleMusicID": "922351495",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-178-Otis-Redding-Otis-blue.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/b9\/f2\/0f\/b9f20fc0-2062-83b2-dc91-c3b488dd8d5f\/603497896219.jpg\/600x600bb.jpg"
         },
         {
             "rank": 179,
@@ -1611,7 +1611,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/life-after-death-2014-remaster\/906888433",
             "appleMusicID": "906888433",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-179-Notorious-BIG-Life-After-Death.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/51\/70\/ca\/5170cae7-3cd5-bc59-18ba-b6f56a1c8359\/603497898848.jpg\/600x600bb.jpg"
         },
         {
             "rank": 180,
@@ -1620,7 +1620,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/forever-changes-remastered\/1125521386",
             "appleMusicID": "1125521386",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-139-Love-Forever-Changes.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/5a\/ee\/47\/5aee470b-8df3-2b3d-f24e-5f79f24350a9\/603497886968.jpg\/600x600bb.jpg"
         },
         {
             "rank": 181,
@@ -1629,7 +1629,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/bringing-it-all-back-home\/177964575",
             "appleMusicID": "177964575",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-181-Bob-Dylan-Bringing-It-All-Back-Home.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/61\/ad\/46\/61ad469e-1e2d-da3c-6847-b939c07924f9\/074640912825.jpg\/600x600bb.jpg"
         },
         {
             "rank": 182,
@@ -1638,7 +1638,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sweet-baby-james-remastered\/1480026454",
             "appleMusicID": "1480026454",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-182-james-taylor-sweet-baby-james.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/ed\/c3\/5a\/edc35aac-57d0-44aa-4969-8bb4c13aed52\/603497849154.jpg\/600x600bb.jpg"
         },
         {
             "rank": 183,
@@ -1647,7 +1647,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/brown-sugar\/1440842296",
             "appleMusicID": "1440842296",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-183-D_Angelo-brown-sugar.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/3d\/b7\/01\/3db701ab-9511-83e3-54d6-a6ccfcf560a2\/13UABIM50177.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 184,
@@ -1656,7 +1656,7 @@
             "year": 1983,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/shes-so-unusual-a-30th-anniversary-celebration\/795192827",
             "appleMusicID": "795192827",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-184-Cyndi-Lauper-Shes-So-Unusual.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/06\/aa\/19\/06aa194a-56af-5dfd-aeae-7fae8c8ea97a\/886444329651.jpg\/600x600bb.jpg"
         },
         {
             "rank": 185,
@@ -1665,7 +1665,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/beggars-banquet-2018-remaster\/1500643395",
             "appleMusicID": "1500643395",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-185-The-Rolling-Stones-Beggars-Banquet.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/a3\/d1\/78\/a3d178a8-f1c2-c1c3-1c5d-d78ab3af9768\/20UMGIM13726.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 186,
@@ -1674,7 +1674,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blood-sugar-sex-magik\/945581828",
             "appleMusicID": "945581828",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-186-Red-Hot-Chili-Peppers-Blood-Sugar-Sex-Magik.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/2b\/2b\/56\/2b2b564c-e21e-bd40-a8cf-cb47dedcb7df\/093624932147.jpg\/600x600bb.jpg"
         },
         {
             "rank": 187,
@@ -1683,7 +1683,7 @@
             "year": 1990,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/amerikkkas-most-wanted\/1422704616",
             "appleMusicID": "1422704616",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-187-Ice-Cube-AmeriKKKas-Most-Wanted.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/a1\/62\/8c\/a1628c8d-f9a9-d278-1a97-ebae7fc3e7d6\/00602547276612.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 188,
@@ -1692,7 +1692,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/electric-warrior\/1440804752",
             "appleMusicID": "1440804752",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-188-T-Rex-Electric-Warrior.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/92\/3a\/99\/923a9920-2a86-e7e3-b177-949dd6c1d023\/00602537055876.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 189,
@@ -1701,7 +1701,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/dig-me-out-2014-remastered-version\/906136610",
             "appleMusicID": "906136610",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-189-Sleater-Kinney-Dig-Me-Out.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/2f\/ad\/dd\/2fadddc8-116d-bc4a-0fbb-77d493a5681c\/SleaterKinney_DigMeOut_1425.jpg\/600x600bb.jpg"
         },
         {
             "rank": 190,
@@ -1710,7 +1710,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/tommy\/1461210985",
             "appleMusicID": "1461210985",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-190-The-Who-Tommy.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/f3\/22\/7f\/f3227fd3-758e-2728-7db2-25b29373c8ae\/18UMGIM35635.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 191,
@@ -1719,7 +1719,7 @@
             "year": 1961,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/at-last\/1440838775",
             "appleMusicID": "1440838775",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-191-etta-james-at-last.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/25\/46\/17\/2546176c-0f7c-b1a0-20b8-5200ebc6c473\/16UMGIM27321.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 192,
@@ -1728,7 +1728,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/licensed-to-ill\/1440912031",
             "appleMusicID": "1440912031",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-192-Beastie-Boys-Licensed-to-Ill.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/e4\/d7\/81\/e4d781e8-bd3f-486a-cd18-e9b3a7d12b34\/00731452735126.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 193,
@@ -1737,7 +1737,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/willy-and-the-poor-boys\/1440950503",
             "appleMusicID": "1440950503",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-193-creedence-clearwater-revival-willy-and-the-poor-boys.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/05\/a0\/ec\/05a0ec77-71e8-a84e-66c9-f17a0dd17170\/00888072356016.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 194,
@@ -1746,7 +1746,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/bad\/559334659",
             "appleMusicID": "559334659",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-194-Michael-Jackson-Bad.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/8d\/97\/f4\/8d97f427-2d17-1a51-1714-324483eb5fc1\/886443546264.jpg\/600x600bb.jpg"
         },
         {
             "rank": 195,
@@ -1755,7 +1755,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/songs-of-leonard-cohen\/191437839",
             "appleMusicID": "191437839",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-195-Leonard-Cohen-Songs-of-Leonard-Cohen.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/f9\/8b\/35\/f98b353b-c623-e7a7-b4c5-567c9d4560f1\/dj.joqdrtxk.jpg\/600x600bb.jpg"
         },
         {
             "rank": 196,
@@ -1764,7 +1764,7 @@
             "year": 2010,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/body-talk-deluxe-version\/481628020",
             "appleMusicID": "481628020",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-196-Robyn-Body-Talk.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/11\/95\/d3\/1195d391-d76f-3297-7adf-d0bb613637fe\/mzi.knsmmmyv.jpg\/600x600bb.jpg"
         },
         {
             "rank": 197,
@@ -1773,7 +1773,7 @@
             "year": 1964,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-197-The-Beatles-Meet-The-Beatles.jpg"
+            "imageURL": null
         },
         {
             "rank": 198,
@@ -1782,7 +1782,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/b-52s\/1440816774",
             "appleMusicID": "1440816774",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-198-b-52s-b-52s.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/92\/9a\/2b\/929a2bd6-7417-77f3-2cc5-c307ca59281e\/15UMGIM22248.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 199,
@@ -1791,7 +1791,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/slanted-enchanted\/1589229771",
             "appleMusicID": "1589229771",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-199-Pavement-Slanted-and-Enchanted.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/bd\/50\/60\/bd506052-0cc6-97b0-ca9e-9f814f726c7e\/744861003854.png\/600x600bb.jpg"
         },
         {
             "rank": 200,
@@ -1800,7 +1800,7 @@
             "year": 1984,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/diamond-life\/1524651063",
             "appleMusicID": "1524651063",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-200-Sade-Diamond-Life.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/4d\/d5\/a1\/4dd5a1b7-7134-f0ec-b55c-54ac47cc88a5\/886448655886.jpg\/600x600bb.jpg"
         },
         {
             "rank": 201,
@@ -1809,7 +1809,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/midnight-marauders\/265670545",
             "appleMusicID": "265670545",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-201-A-Tribe-Called-Quest-Midnight-Marauders.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/d1\/90\/11\/d1901153-4595-7f2f-12d2-661be9eef883\/012414149022.jpg\/600x600bb.jpg"
         },
         {
             "rank": 202,
@@ -1818,7 +1818,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/homogenic\/1395923200",
             "appleMusicID": "1395923200",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-202-BjOrk-Homogenic.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/58\/30\/a9\/5830a990-f96d-4300-9a93-2b7092cfda97\/05016958995089.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 203,
@@ -1827,7 +1827,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pink-moon\/1567147188",
             "appleMusicID": "1567147188",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-203-Nick-Drake-Pink-Moon.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/66\/d5\/9a\/66d59a9f-c2d4-8da2-7053-ea2e97f0b7f7\/21UMGIM38174.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 204,
@@ -1836,7 +1836,7 @@
             "year": 2007,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/graduation\/1451901307",
             "appleMusicID": "1451901307",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-204-Kanye-West-Graduation.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/2f\/db\/2c\/2fdb2c9d-171c-c6dc-57ee-4bae2b4bb11a\/07UMGIM12671.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 205,
@@ -1845,7 +1845,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/tea-for-the-tillerman-2020-remaster\/1535560790",
             "appleMusicID": "1535560790",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-205-Cat-Stevens-Tea-for-the-Tillerman.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/fc\/e6\/a9\/fce6a952-aa1b-4c75-50d5-da7716d1bd5c\/20UMGIM86272.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 206,
@@ -1854,7 +1854,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/low-2017-remaster\/1347895593",
             "appleMusicID": "1347895593",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-206-David-Bowie-Low.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/f7\/49\/2d\/f7492da6-164e-b023-4b17-937329c35458\/190295842895.jpg\/600x600bb.jpg"
         },
         {
             "rank": 207,
@@ -1863,7 +1863,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/eagles\/635791801",
             "appleMusicID": "635791801",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-207-Eagles-the-Eagles.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/8f\/e7\/f4\/8fe7f417-d464-8879-b00e-3d4965a9cfd1\/075596062329.jpg\/600x600bb.jpg"
         },
         {
             "rank": 208,
@@ -1872,7 +1872,7 @@
             "year": 2008,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/tha-carter-iii-deluxe-revised\/1452792123",
             "appleMusicID": "1452792123",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-208-Lil-Wayne-Tha-Carter-III.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/73\/3d\/77\/733d7764-05cc-c28b-b92d-4682c2d62eb6\/08UMGIM18842.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 209,
@@ -1881,7 +1881,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/raising-hell-expanded-edition\/1308514619",
             "appleMusicID": "1308514619",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-209-run-dmc-Raising-Hell.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/22\/e8\/6f\/22e86f93-fc7b-a6da-1a70-b7f8de339121\/888880788566.jpg\/600x600bb.jpg"
         },
         {
             "rank": 210,
@@ -1890,7 +1890,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-birth-of-soul-the-complete-atlantic\/275968936",
             "appleMusicID": "275968936",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-210-Ray-Charles-the-Birth-of-Soul.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music3\/v4\/7b\/ae\/f1\/7baef164-5d80-e2bc-0333-7eef1e0e5027\/dj.rysmdnjf.jpg\/600x600bb.jpg"
         },
         {
             "rank": 211,
@@ -1899,7 +1899,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/unknown-pleasures-2019-remaster\/1476702180",
             "appleMusicID": "1476702180",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-211-Joy-Division-Unknown-Pleasures.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/13\/90\/c0\/1390c072-4249-3739-7b3d-fd73ee4a5698\/825646562831.jpg\/600x600bb.jpg"
         },
         {
             "rank": 212,
@@ -1908,7 +1908,7 @@
             "year": 1966,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/wild-is-the-wind\/1469552026",
             "appleMusicID": "1469552026",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-212-Nina-Simone-Wild-is-the-Wind.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/f6\/35\/43\/f6354340-5726-f519-8cc5-ed277ac11b2d\/13UAAIM08288.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 213,
@@ -1917,7 +1917,7 @@
             "year": 2012,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-idler-wheel-is-wiser-than-the-driver-of\/1462213924",
             "appleMusicID": "1462213924",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-213-Fiona-Apple-The-Idler-Wheel.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/be\/ce\/2e\/bece2e46-bd11-389b-bf82-8b647fa50731\/886443478671.jpg\/600x600bb.jpg"
         },
         {
             "rank": 214,
@@ -1926,7 +1926,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/wildflowers\/892018539",
             "appleMusicID": "892018539",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-214-Tom-Petty-Wildflowers.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/a0\/04\/20\/a004206c-6830-2f4d-a99d-595b4964666d\/093624937456.jpg\/600x600bb.jpg"
         },
         {
             "rank": 215,
@@ -1935,7 +1935,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/american-beauty\/664831661",
             "appleMusicID": "664831661",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-215-Grateful-Dead-American-Beauty.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/f5\/27\/20\/f5272061-2466-6375-c2d1-f20d14be569f\/603497920952.jpg\/600x600bb.jpg"
         },
         {
             "rank": 216,
@@ -1944,7 +1944,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/either-or\/1440837211",
             "appleMusicID": "1440837211",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-216-Elliott-Smith-Either_Or.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/9b\/33\/70\/9b337013-194a-86e6-b115-af191897e1b2\/00602547529404.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 217,
@@ -1953,7 +1953,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/definitely-maybe\/1517506402",
             "appleMusicID": "1517506402",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-217-Oasis-Definitely-Maybe.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/9f\/e7\/ea\/9fe7eac2-87dc-c1df-3333-dc30b82bdd74\/5051961006100.jpg\/600x600bb.jpg"
         },
         {
             "rank": 218,
@@ -1962,7 +1962,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/crazysexycool\/270246704",
             "appleMusicID": "270246704",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-218-TLC-CrazySexyCool.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/14\/a8\/69\/14a86912-841d-3cb8-cf55-0439b15c6cab\/dj.mjduepez.jpg\/600x600bb.jpg"
         },
         {
             "rank": 219,
@@ -1971,7 +1971,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/only-built-4-cuban-linx\/258634938",
             "appleMusicID": "258634938",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-219-Raekwon-Only-Built-4-Cuban-Linx.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/e1\/b1\/de\/e1b1de50-cca7-28d1-9e40-00c2251ead3d\/078636666327.jpg\/600x600bb.jpg"
         },
         {
             "rank": 220,
@@ -1980,7 +1980,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/d\u00e9j\u00e0-vu-50th-anniversary-deluxe-edition\/1556346195",
             "appleMusicID": "1556346195",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-220-CSNY-Deja-Vu.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/1c\/bb\/59\/1cbb59cc-be85-9db7-9762-65c525e07c81\/603497845613.jpg\/600x600bb.jpg"
         },
         {
             "rank": 221,
@@ -1989,7 +1989,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rage-against-the-machine\/191450810",
             "appleMusicID": "191450810",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-221-Rage-Against-the-Machine-Rage-Against-the-Machine.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/8e\/08\/bf\/8e08bf66-8690-1ba7-affb-fe173c08623d\/074645295923.jpg\/600x600bb.jpg"
         },
         {
             "rank": 222,
@@ -1998,7 +1998,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ray-of-light\/952887",
             "appleMusicID": "952887",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-222-Madonna-Ray-Of-Light.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/dd\/2b\/8d\/dd2b8d84-e032-94d2-473a-3f8efd18fe36\/dj.rwfgroxa.jpg\/600x600bb.jpg"
         },
         {
             "rank": 223,
@@ -2007,7 +2007,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/imagine-the-ultimate-collection\/1428571018",
             "appleMusicID": "1428571018",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-223-John-Lennon-Imagine.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/51\/d8\/a9\/51d8a94b-311b-db29-af0e-44dff1351b48\/18UMGIM51037.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 224,
@@ -2016,7 +2016,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/fly\/309893729",
             "appleMusicID": "309893729",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-224-Dixie-Chicks-FLY.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/7c\/39\/60\/7c3960ca-c0f1-8a47-1be8-1b6dd8ed3a50\/dj.wtjjbgin.jpg\/600x600bb.jpg"
         },
         {
             "rank": 225,
@@ -2025,7 +2025,7 @@
             "year": 2001,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/yankee-hotel-foxtrot-deluxe-edition\/1619388499",
             "appleMusicID": "1619388499",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-225-wilco-yankee-hotel-foxtrot.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/db\/88\/16\/db881666-5e1c-6953-41fd-721b0560154b\/075597913354.jpg\/600x600bb.jpg"
         },
         {
             "rank": 226,
@@ -2034,7 +2034,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/layla-and-other-assorted-love-songs-40th-anniversary\/1422651922",
             "appleMusicID": "1422651922",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-226-Derek-and-the-Dominos-Layla-and-Other-Assorted-Love-Songs.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/ea\/98\/9e\/ea989e72-4a2c-3d64-2e77-b2f4f72dc925\/00600753330449.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 227,
@@ -2043,7 +2043,7 @@
             "year": 1957,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/heres-little-richard-mono-version\/765764424",
             "appleMusicID": "765764424",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-227-Little-Richard-Heres-Little-Richard.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music4\/v4\/ed\/41\/96\/ed419696-be41-947a-ba07-3d99f8b74548\/cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 228,
@@ -2052,7 +2052,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/de-la-soul-is-dead\/1664602251",
             "appleMusicID": "1664602251",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-228-De-La-Soul-De-la-Soul-is-dead.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/79\/65\/af\/7965af42-1973-8f4c-ab48-3e4bd03dde17\/810098503105.png\/600x600bb.jpg"
         },
         {
             "rank": 229,
@@ -2061,7 +2061,7 @@
             "year": 2000,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/patsy-clines-greatest-hits\/1440825668",
             "appleMusicID": "1440825668",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-229-Patsy-Cline-The-Ultimate-Collection.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/36\/5f\/6e\/365f6e54-36ff-cb2b-4f85-8dae17a5535c\/14UMGIM00863.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 230,
@@ -2070,7 +2070,7 @@
             "year": 2016,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/anti-deluxe\/1440933869",
             "appleMusicID": "1440933869",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-230-Rihanna-ANTI.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/11\/e9\/60\/11e9600c-7f3a-424b-1643-97c69f7e8067\/16UMGIM03373.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 231,
@@ -2079,7 +2079,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/damn-the-torpedoes\/1440860187",
             "appleMusicID": "1440860187",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-231-Tom-Petty-Damn-the-Torpedoes.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/95\/c8\/d5\/95c8d554-d5af-4c45-0f01-b5e49d1a33e5\/06UMGIM05167.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 232,
@@ -2088,7 +2088,7 @@
             "year": 1960,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/giant-steps-2020-remaster\/1531037502",
             "appleMusicID": "1531037502",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-232-John-Coltrane-Giant-Steps.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/4e\/2f\/8b\/4e2f8b1f-7e14-1ce4-1c76-4683b1b9173d\/603497847549.jpg\/600x600bb.jpg"
         },
         {
             "rank": 233,
@@ -2097,7 +2097,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/little-earthquakes-remastered\/981370459",
             "appleMusicID": "981370459",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-233-Tori-Amos-Little-Earthquakes.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music1\/v4\/cc\/1b\/32\/cc1b322d-bbdb-7b96-ea99-d006a2266d1f\/603497892938.jpg\/600x600bb.jpg"
         },
         {
             "rank": 234,
@@ -2106,7 +2106,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/master-of-reality\/1440217659",
             "appleMusicID": "1440217659",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-234-Black-Sabbath-Master-of-Reality.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/11\/2a\/b1\/112ab10f-c4c6-d3c5-ca82-48b24627d290\/0602537422722.jpg\/600x600bb.jpg"
         },
         {
             "rank": 235,
@@ -2115,7 +2115,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/metallica-remastered\/1571968136",
             "appleMusicID": "1571968136",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-235-metallica-black.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/c6\/9b\/1d\/c69b1ddb-f873-53b4-9fc9-87ca49af2062\/21UMGIM48676.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 236,
@@ -2124,7 +2124,7 @@
             "year": 2001,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/discovery\/697194953",
             "appleMusicID": "697194953",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-236-Daft-Punk-Discovery.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features125\/v4\/9e\/f3\/19\/9ef31946-26de-0a95-c771-30457c5c01ec\/dj.huxlnxyy.jpg\/600x600bb.jpg"
         },
         {
             "rank": 237,
@@ -2133,7 +2133,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/red-headed-stranger\/404365971",
             "appleMusicID": "404365971",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-237-Willie-Nelson-Red-Headed-Stranger.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music123\/v4\/88\/d6\/67\/88d6676e-67ce-f907-d4fe-eae50f805f63\/074643348225.jpg\/600x600bb.jpg"
         },
         {
             "rank": 238,
@@ -2142,7 +2142,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/trans-europe-express-remastered\/726144557",
             "appleMusicID": "726144557",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-238-Kraftwerk-Trans-Europe-Express.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e2\/80\/bc\/e280bcf9-4048-8c42-2b6b-d8b9c9bbed52\/5099996602058_1500x1500_300dpi.jpg\/600x600bb.jpg"
         },
         {
             "rank": 239,
@@ -2151,7 +2151,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/criminal-minded\/1094407338",
             "appleMusicID": "1094407338",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-239-Boogie-Down-Productions-Criminal-minded.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/aa\/33\/f7\/aa33f735-a078-50ad-8f84-27415f83292d\/BB-2006_-_Boogie_Down_Productions_-_Criminal_Minded.jpg\/600x600bb.jpg"
         },
         {
             "rank": 240,
@@ -2160,7 +2160,7 @@
             "year": 1985,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/one-night-stand-live-at-the-harlem-square-club-1963\/304822401",
             "appleMusicID": "304822401",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-240-Sam-Cooke-Live-at-the-Harlem-Square-Club-1963.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features124\/v4\/b1\/80\/5e\/b1805ee4-39d3-32d6-0aef-e07595ec218a\/dj.xndujmfn.jpg\/600x600bb.jpg"
         },
         {
             "rank": 241,
@@ -2169,7 +2169,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blue-lines-2012-mix-master\/715864097",
             "appleMusicID": "715864097",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-241-Massive-Attack-Blue-Lines.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e5\/f7\/c0\/e5f7c07d-2182-e732-8ad6-be03814fe93c\/13UABIM04453.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 242,
@@ -2178,7 +2178,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/loaded-remastered\/1050415251",
             "appleMusicID": "1050415251",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-242-The-Velvet-Underground-Loaded.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/87\/7d\/5e\/877d5e8d-8aff-717f-576c-f237ee8d7a34\/603497884575.jpg\/600x600bb.jpg"
         },
         {
             "rank": 243,
@@ -2187,7 +2187,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/odessey-and-oracle\/1719880807",
             "appleMusicID": "1719880807",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-243-The-Zombies-Odessey-and-Oracle.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/04\/fb\/f9\/04fbf987-1a18-5fc3-3a46-75d454325fa7\/842108020548.png\/600x600bb.jpg"
         },
         {
             "rank": 244,
@@ -2196,7 +2196,7 @@
             "year": 2008,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/808s-heartbreak-exclusive-edition\/1609149054",
             "appleMusicID": "1609149054",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-244-Kanye-West-808s-_-Heartbreak.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/f3\/61\/19\/f36119b9-4d88-05eb-4306-2ae0e7decf88\/08UMGIM26559.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 245,
@@ -2205,7 +2205,7 @@
             "year": 1990,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/heaven-or-las-vegas-remastered\/258198881",
             "appleMusicID": "258198881",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-245-Cocteau-Twins-Heaven-or-Las-Vegas.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/76\/cd\/61\/76cd61e7-0714-dce5-c48e-0f05f8fcb84b\/652637001280.png\/600x600bb.jpg"
         },
         {
             "rank": 246,
@@ -2214,7 +2214,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/mama-said-knock-you-out\/1443212742",
             "appleMusicID": "1443212742",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-246-LL-cool-J-Mama-Said-Knock-You-Out.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/74\/82\/a0\/7482a0f8-52d7-d5d3-ea57-176ee6ec3f4c\/00602547742278.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 247,
@@ -2223,7 +2223,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/love-deluxe\/158796559",
             "appleMusicID": "158796559",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-247-Sade-Love-Deluxe.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/18\/c8\/d7\/18c8d7bc-8491-09e6-df0d-6e0a83ead680\/mzi.wsikzifg.jpg\/600x600bb.jpg"
         },
         {
             "rank": 248,
@@ -2232,7 +2232,7 @@
             "year": 2004,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/american-idiot-deluxe-edition\/207192731",
             "appleMusicID": "207192731",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-248-Green-Day-American-Idiot.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/9e\/17\/c2\/mzi.ofggkufy.jpg\/600x600bb.jpg"
         },
         {
             "rank": 249,
@@ -2241,7 +2241,7 @@
             "year": 1985,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/whitney-houston\/211392924",
             "appleMusicID": "211392924",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-249-Whitney-Houston-Whitney-Houston.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features115\/v4\/57\/ab\/ee\/57abee5e-6e30-eaaa-6d9c-e4f2ec360b72\/dj.tqbekvrp.jpg\/600x600bb.jpg"
         },
         {
             "rank": 250,
@@ -2250,7 +2250,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/singles-going-steady-deluxe-version\/1251022568",
             "appleMusicID": "1251022568",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-250-buzzcocks-singles-going-steady.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/3d\/eb\/e2\/3debe2f4-53a1-58bd-58da-bca90905d014\/887830012966.png\/600x600bb.jpg"
         },
         {
             "rank": 251,
@@ -2259,7 +2259,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/honky-ch\u00e2teau-bonus-track-version\/1440910513",
             "appleMusicID": "1440910513",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-251-Elton-John-HONKY-CHATEAU.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/75\/b6\/da\/75b6da76-a3e0-6a77-cbe5-ad6c42cb0692\/06UMGIM48050.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 252,
@@ -2268,7 +2268,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/q-are-we-not-men-a-we-are-devo-devo-live\/724912387",
             "appleMusicID": "724912387",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-252-Devo-Q-Are-We-Not-Men-A-We-Are-Devo.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music4\/v4\/4f\/68\/c3\/4f68c370-033d-e1d4-6fc0-89b3508fe47c\/00077778699651.jpg\/600x600bb.jpg"
         },
         {
             "rank": 253,
@@ -2277,7 +2277,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-piper-at-the-gates-of-dawn\/699637401",
             "appleMusicID": "699637401",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-253-Pink-Floyd-Piper-At-The-Gates-of-Dawn.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music6\/v4\/f5\/ef\/56\/f5ef56f4-11fa-67fe-41d0-3ec997fc9234\/5099968076153_1500x1500_300dpi.jpg\/600x600bb.jpg"
         },
         {
             "rank": 254,
@@ -2286,7 +2286,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/head-hunters\/158571524",
             "appleMusicID": "158571524",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-254-Herbie-Hancock-Head-Hunters.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/4f\/e5\/f5\/4fe5f511-462e-e87b-0711-d4e42809fb17\/dj.goshfswo.jpg\/600x600bb.jpg"
         },
         {
             "rank": 255,
@@ -2295,7 +2295,7 @@
             "year": 1963,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-freewheelin-bob-dylan\/190758914",
             "appleMusicID": "190758914",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-255-Bob-Dylan-The-Freewheelin-Bob-Dylan.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/63\/3c\/98\/633c98ab-b4f3-3f40-798b-bdb49d923468\/074640878626.jpg\/600x600bb.jpg"
         },
         {
             "rank": 256,
@@ -2304,7 +2304,7 @@
             "year": 1988,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/tracy-chapman\/79565550",
             "appleMusicID": "79565550",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-256-Tracy-Chapman-Tracy-Chapman.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/b8\/c4\/31\/b8c431e9-a67d-3917-72e5-be9f5a1ebc46\/075596077460.jpg\/600x600bb.jpg"
         },
         {
             "rank": 257,
@@ -2313,7 +2313,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/coat-of-many-colors\/217532812",
             "appleMusicID": "217532812",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-257-Dolly-Parton-Coat-of-Many-Colors.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/9b\/1d\/11\/9b1d1141-2332-5100-822a-0cd571ebffd6\/dj.zuericqk.jpg\/600x600bb.jpg"
         },
         {
             "rank": 258,
@@ -2322,7 +2322,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-hissing-of-summer-lawns-2022-remaster\/1653396646",
             "appleMusicID": "1653396646",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-258-Joni-mitchell-Hissing-of-Summer-Lawns.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/f9\/47\/45\/f9474535-1e68-04a6-3dbc-d5b04f09e66f\/603497833474.jpg\/600x600bb.jpg"
         },
         {
             "rank": 259,
@@ -2331,7 +2331,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pearl\/917030890",
             "appleMusicID": "917030890",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-259-janis-joplin-pearl.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/16\/9d\/87\/169d87fe-76ee-1c50-d186-14ac71ab237e\/886443610538.jpg\/600x600bb.jpg"
         },
         {
             "rank": 260,
@@ -2340,7 +2340,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/cut\/1440911059",
             "appleMusicID": "1440911059",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-260-The-Slits-Cut.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/7e\/2a\/83\/7e2a8321-7924-62aa-350e-d7ab03a3a945\/00731454818629.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 261,
@@ -2349,7 +2349,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/check-your-head-deluxe-version-remastered\/724303425",
             "appleMusicID": "724303425",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-261-Beastie-Boys-Check-Your-Head.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/v4\/90\/da\/e6\/90dae601-912e-db42-923a-a832107c901d\/05099969422553.jpg\/600x600bb.jpg"
         },
         {
             "rank": 262,
@@ -2358,7 +2358,7 @@
             "year": 1983,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/power-corruption-and-lies-definitive\/1526142923",
             "appleMusicID": "1526142923",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-262-New-Order-Power-Corruption-_-Lies.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/68\/d3\/13\/68d31343-dbc6-fae0-c633-3ddcbd105f3a\/190295420291.jpg\/600x600bb.jpg"
         },
         {
             "rank": 263,
@@ -2367,7 +2367,7 @@
             "year": 1964,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/a-hard-days-night\/1441164416",
             "appleMusicID": "1441164416",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-263-the-beatles-a-hard-days-night.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/db\/a2\/7a\/dba27a46-3685-508d-d32e-a0e73cc82251\/00602567713296.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 264,
@@ -2376,7 +2376,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/wish-you-were-here\/704223460",
             "appleMusicID": "704223460",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-264-Pink-Floyd-Wish-You-Were-Here.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/3b\/22\/4d\/3b224dad-38e5-fee8-e067-a32e5837cf97\/5099968084257.jpg\/600x600bb.jpg"
         },
         {
             "rank": 265,
@@ -2385,7 +2385,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/wowee-zowee-sordid-sentinels-edition\/1589152357",
             "appleMusicID": "1589152357",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-265-Pavement-Wowee-Zowee.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/77\/ee\/5c\/77ee5c49-87c9-c5c3-0a4a-be42743c916b\/744861072263.png\/600x600bb.jpg"
         },
         {
             "rank": 266,
@@ -2394,7 +2394,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/help\/1441164524",
             "appleMusicID": "1441164524",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-266-BeatlesHELP.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/1a\/19\/db\/1a19db26-17ad-b986-11a9-f72ac7a6194b\/18UMGIM31214.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 267,
@@ -2403,7 +2403,7 @@
             "year": 1984,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/double-nickels-on-the-dime\/117012391",
             "appleMusicID": "117012391",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-267-Minutemen-double-nickels-on-the-dime.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/81\/35\/33\/813533c9-c6f8-c172-75e4-c26c35859601\/dj.aieliucv.jpg\/600x600bb.jpg"
         },
         {
             "rank": 268,
@@ -2412,7 +2412,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sail-away-bonus-tracks-version-2002-remaster\/51963348",
             "appleMusicID": "51963348",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-268-Randy-Newman-Sail-Away.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/y2005\/m03\/d21\/h21\/s06.zkjucsjk.jpg\/600x600bb.jpg"
         },
         {
             "rank": 269,
@@ -2421,7 +2421,7 @@
             "year": 2013,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/yeezus\/1440873068",
             "appleMusicID": "1440873068",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-269-Kanye-West-Yeezus.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/3c\/56\/e7\/3c56e717-06a0-b67d-e694-9b6e6e43a5a8\/13UAAIM08444.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 270,
@@ -2430,7 +2430,7 @@
             "year": 2018,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/golden-hour\/1440918116",
             "appleMusicID": "1440918116",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-270-kacey-musgraves-Golden-Hour.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/61\/45\/e8\/6145e88a-6a79-fab1-ad8f-5ffdcbf44a28\/18UMGIM03879.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 271,
@@ -2439,7 +2439,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/whats-the-411\/1440817005",
             "appleMusicID": "1440817005",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-271-Mary-J-Blige-Whats-the-411_.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/43\/54\/ba\/4354ba48-b993-9c58-af75-2987f1d2fcab\/06UMGIM05898.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 272,
@@ -2448,7 +2448,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/white-light-white-heat-45th-anniversary-edition\/1469578042",
             "appleMusicID": "1469578042",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-272-Velvet-Underground-White-Light-White-Heat.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music123\/v4\/ee\/ac\/91\/eeac9154-5178-ebbc-be57-81bfb11f8ce7\/00602537589678.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 273,
@@ -2457,7 +2457,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/entertainment\/1028712191",
             "appleMusicID": "1028712191",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-273-Gang-of-Four-Entertainment.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/cd\/a3\/06\/cda306e6-3990-978c-2b54-e3638363969c\/mzm.mwjizabp.jpg\/600x600bb.jpg"
         },
         {
             "rank": 274,
@@ -2466,7 +2466,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sweetheart-of-the-rodeo\/281801812",
             "appleMusicID": "281801812",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-274-Byrds-Sweetheart-of-the-Rodeo.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/0d\/10\/77\/mzi.lqtckddu.jpg\/600x600bb.jpg"
         },
         {
             "rank": 275,
@@ -2475,7 +2475,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/curtis-expanded-edition\/29168201",
             "appleMusicID": "29168201",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-275-Curtis-Mayfield-Curtis.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/f9\/37\/7e\/f9377e37-bad1-6aee-c672-a9a0bf37cdd4\/081227847562.jpg\/600x600bb.jpg"
         },
         {
             "rank": 276,
@@ -2484,7 +2484,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-bends\/1097862703",
             "appleMusicID": "1097862703",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-276-radiohead-the-bends.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/1b\/a9\/5c\/1ba95cac-b245-d386-63fb-6b857aa9dce8\/634904078065.png\/600x600bb.jpg"
         },
         {
             "rank": 277,
@@ -2493,7 +2493,7 @@
             "year": 2003,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-diary-of-alicia-keys\/255342344",
             "appleMusicID": "255342344",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-277-Alicia-Keys-The-Diary-of-Alicia-Keys.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/c2\/07\/c6\/c207c6ee-e3f1-cad2-1259-69a3ebd08b5c\/828765571227.jpg\/600x600bb.jpg"
         },
         {
             "rank": 278,
@@ -2502,7 +2502,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/houses-of-the-holy-remastered\/580707916",
             "appleMusicID": "580707916",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-278-Led-Zeppelin-Houses-of-the-Holy.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/4f\/88\/ad\/4f88ad28-3953-fded-6c18-fe87b5d0dc7b\/dj.iqdrlirx.jpg\/600x600bb.jpg"
         },
         {
             "rank": 279,
@@ -2511,7 +2511,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/mtv-unplugged-in-new-york-live-acoustic\/1440892370",
             "appleMusicID": "1440892370",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-279-Nirvana-MTV-Unplugged.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/46\/24\/33\/462433f9-ee74-2d60-4538-859826a7bed7\/00720642472729.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 280,
@@ -2520,7 +2520,7 @@
             "year": 2002,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/get-rich-or-die-tryin-bonus-track-version\/1440841450",
             "appleMusicID": "1440841450",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-280-50-cent-Get-Rich-or-Die-Trying.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/51\/a6\/c9\/51a6c989-f81d-42b3-c94c-e889a7c07885\/06UMGIM15592.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 281,
@@ -2529,7 +2529,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/nilsson-schmilsson\/304815001",
             "appleMusicID": "304815001",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-281-Harry-Nilsson-Nilsson-Schmilsson.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/f7\/f1\/bf\/f7f1bf43-3324-6c2d-d7e0-368d506fd56d\/078635451528.jpg\/600x600bb.jpg"
         },
         {
             "rank": 282,
@@ -2538,7 +2538,7 @@
             "year": 1955,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/in-the-wee-small-hours\/1440815019",
             "appleMusicID": "1440815019",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-282-Frank-Sinatra-In-the-Wee-Small-Hours.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/97\/a7\/42\/97a7424f-8161-052f-ce3c-93730c2d30de\/14UMGIM32540.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 283,
@@ -2547,7 +2547,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/bad-girls\/1425179100",
             "appleMusicID": "1425179100",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-283-Donna-Summer-Bad-Girls.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/66\/a7\/b0\/66a7b03a-c02c-73c2-c7f2-f2afdf05a8dc\/06UMGIM04498.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 284,
@@ -2556,7 +2556,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/down-every-road-1962-1994\/716720126",
             "appleMusicID": "716720126",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-284-Merle-haggard-Down-Every-Road.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/6f\/c8\/9a\/6fc89a43-b4cf-b1b7-99f2-4a8ea2b8ce0c\/13ULAIM49214.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 285,
@@ -2565,7 +2565,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/third\/1098290738",
             "appleMusicID": "1098290738",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-285-Big-Star-Third-Sister-Lovers.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music49\/v4\/5a\/9d\/04\/5a9d049f-acd3-ab96-5cbc-e3b181b9aead\/766887857556.jpg\/600x600bb.jpg"
         },
         {
             "rank": 286,
@@ -2574,7 +2574,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/californication-remastered\/945575406",
             "appleMusicID": "945575406",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-286-Red-Hot-Chili-Peppers-Californication.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/4c\/86\/1d\/4c861dab-5428-f3b7-8068-82bb69db5e89\/093624932130.jpg\/600x600bb.jpg"
         },
         {
             "rank": 287,
@@ -2583,7 +2583,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/mr-tambourine-man\/251989391",
             "appleMusicID": "251989391",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-287-The-Byrds-Mr-Tambourine-Man.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/c2\/02\/e5\/mzi.zvoyckye.jpg\/600x600bb.jpg"
         },
         {
             "rank": 288,
@@ -2592,7 +2592,7 @@
             "year": 1976,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-modern-lovers\/1433774364",
             "appleMusicID": "1433774364",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-288-Modern-Lovers-Modern-Lovers.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/68\/be\/11\/68be1164-03b3-1b03-01ba-c7a1abefa7d5\/5414939481475.jpg\/600x600bb.jpg"
         },
         {
             "rank": 289,
@@ -2601,7 +2601,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/post\/1395925892",
             "appleMusicID": "1395925892",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-289-Bjork-Post.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/a6\/ca\/da\/a6cadac1-82d3-6b02-d878-68308eab1ba4\/05016958995072.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 290,
@@ -2610,7 +2610,7 @@
             "year": 2003,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/speakerboxxx-the-love-below\/281430653",
             "appleMusicID": "281430653",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-290-Outkast-Speakerbox-The-Love-Below.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/32\/67\/b6\/3267b6af-b17b-0ff3-f44d-10d489185ab1\/828765013321.jpg\/600x600bb.jpg"
         },
         {
             "rank": 291,
@@ -2619,7 +2619,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-writings-on-the-wall\/324210874",
             "appleMusicID": "324210874",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-291-Destinys-Child-Writings-on-The-Wall.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/9b\/77\/a9\/mzi.idjwpnmb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 292,
@@ -2628,7 +2628,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/van-halen\/976820530",
             "appleMusicID": "976820530",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-292-Van-Halen-Van-Halen.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/7a\/ef\/88\/7aef88ad-25aa-be91-eb78-8917c3f114f7\/603497894130.jpg\/600x600bb.jpg"
         },
         {
             "rank": 293,
@@ -2637,7 +2637,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/last-splash-30th-anniversary-edition\/1691135003",
             "appleMusicID": "1691135003",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-293-The-Breeders-Last-Splash.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/48\/48\/b1\/4848b127-2daa-bcd0-84f6-346851cec648\/191400061156.png\/600x600bb.jpg"
         },
         {
             "rank": 294,
@@ -2646,7 +2646,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/weezer\/1440878798",
             "appleMusicID": "1440878798",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-294-Weezer-The-Blue-Album.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/fc\/74\/67\/fc74674a-1eb0-d50d-33fe-215caee529d1\/16UMGIM52971.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 295,
@@ -2655,7 +2655,7 @@
             "year": 2013,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/random-access-memories\/617154241",
             "appleMusicID": "617154241",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-295-Daft-Punk-Random-Access-Memories.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e8\/43\/5f\/e8435ffa-b6b9-b171-40ab-4ff3959ab661\/886443919266.jpg\/600x600bb.jpg"
         },
         {
             "rank": 296,
@@ -2664,7 +2664,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rust-never-sleeps\/1015767135",
             "appleMusicID": "1015767135",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-296-Neil-Young-Rust-Never-Sleeps.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music1\/v4\/9a\/65\/18\/9a6518c2-850f-f40a-5bad-540a9ef4ad70\/093624924708.jpg\/600x600bb.jpg"
         },
         {
             "rank": 297,
@@ -2673,7 +2673,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/so\/986800858",
             "appleMusicID": "986800858",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-297peter-gabriel-so.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/29\/d7\/7d\/29d77d60-24b8-f45b-936f-d8cf3ce52d8d\/884108003503.jpg\/600x600bb.jpg"
         },
         {
             "rank": 298,
@@ -2682,7 +2682,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/full-moon-fever\/1440825367",
             "appleMusicID": "1440825367",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-298-Tom-Petty-Full-Moon-Fever.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/f3\/71\/47\/f37147d5-d029-880b-bdc1-5929c907909a\/06UMGIM04214.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 299,
@@ -2691,7 +2691,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/live-at-the-regal\/1440831941",
             "appleMusicID": "1440831941",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-299-BB-King-Live-at-the-Regal.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/bc\/fa\/b8\/bcfab88a-c67d-54c2-418d-dcd28420a507\/00602547481955.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 300,
@@ -2700,7 +2700,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/come-on-over-special-edition\/1654843726",
             "appleMusicID": "1654843726",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-300-Shania-Twain-Come-on-Over.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/29\/35\/e3\/2935e37d-e034-2b39-ef0b-1344865ebed6\/22UM1IM08219.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 301,
@@ -2709,7 +2709,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/new-york-dolls\/1445885111",
             "appleMusicID": "1445885111",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-301-NEW-YORK-DOLLS-New-York-Dolls.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/9f\/bf\/68\/9fbf68a5-f2f2-6f89-3576-964c4fffb5ff\/00602537890804.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 302,
@@ -2718,7 +2718,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/tonights-the-night\/1015773462",
             "appleMusicID": "1015773462",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-302-Neil-Young-Tonight_s-the-Night.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music7\/v4\/a5\/17\/c5\/a517c57d-4f39-2227-bd56-8bb96e438827\/093624924692.jpg\/600x600bb.jpg"
         },
         {
             "rank": 303,
@@ -2727,7 +2727,7 @@
             "year": 2001,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-essential-collection\/1444205055",
             "appleMusicID": "1444205055",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-303-ABBA-The-Definitive-Collection.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/da\/2f\/7d\/da2f7d7b-4ad0-ffd7-da8a-a638740a0953\/12UMGIM14101.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 304,
@@ -2736,7 +2736,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/just-as-i-am\/293521570",
             "appleMusicID": "293521570",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-304-Bill-Withers-Just-As-I-Am.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/1b\/b9\/16\/1bb9167c-e0eb-5418-960d-e9adb61d0fdd\/mzi.kqpazwnw.jpg\/600x600bb.jpg"
         },
         {
             "rank": 305,
@@ -2745,7 +2745,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/alive\/1442677510",
             "appleMusicID": "1442677510",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-305-Kiss-Alive.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/e5\/43\/65\/e54365c5-d8d6-d721-f9e6-bb58b64f07af\/00602537885206.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 306,
@@ -2754,7 +2754,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/im-still-in-love-with-you\/1133378411",
             "appleMusicID": "1133378411",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-306-Al-Green-I_m-Still-in-Love-with-You.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/43\/be\/6e\/43be6e38-9e0d-f1e5-3dba-9911abf418f1\/886445997743.jpg\/600x600bb.jpg"
         },
         {
             "rank": 307,
@@ -2763,7 +2763,7 @@
             "year": 2003,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/30-greatest-hits-portrait-of-a-legend-1951-1964\/1440771554",
             "appleMusicID": "1440771554",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-307-Sam-Cooke-Portrait-of-a-Legend.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/2e\/21\/25\/2e212537-9fde-0933-ba2b-641bb2543f8e\/00018771326427.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 308,
@@ -2772,7 +2772,7 @@
             "year": 1974,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/here-come-the-warm-jets\/723783174",
             "appleMusicID": "723783174",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-308-Brian-Eno-Here-Come-The-Warm-Jets.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/75\/1d\/1f\/751d1fcf-a66e-94f5-4d65-b7f636709235\/00724357729352.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 309,
@@ -2781,7 +2781,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/closer-collectors-edition\/266610001",
             "appleMusicID": "266610001",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-309-joy-division-closer.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features114\/v4\/d9\/2a\/d1\/d92ad12e-cdf2-e567-9612-af2fdfa82237\/dj.uzqznczn.jpg\/600x600bb.jpg"
         },
         {
             "rank": 310,
@@ -2790,7 +2790,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pink-flag\/1328682500",
             "appleMusicID": "1328682500",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-310-Wire-Pink-FLag.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/f9\/e2\/e4\/f9e2e407-e1ee-4bef-28d9-4e0ad79cdf3e\/cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 311,
@@ -2799,7 +2799,7 @@
             "year": 1974,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/on-the-beach\/1015732002",
             "appleMusicID": "1015732002",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-311-Neil-Young-On-The-Beach.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music5\/v4\/df\/58\/ad\/df58ada0-61d7-6b41-ceb4-b219ca5dc088\/093624924715.jpg\/600x600bb.jpg"
         },
         {
             "rank": 312,
@@ -2808,7 +2808,7 @@
             "year": 2016,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/a-seat-at-the-table\/1159507212",
             "appleMusicID": "1159507212",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-312-Solange-A-Seat-At-The-Table.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/76\/2b\/c4\/762bc430-fae3-3262-ef16-bd74bad9cdea\/886446143170.jpg\/600x600bb.jpg"
         },
         {
             "rank": 313,
@@ -2817,7 +2817,7 @@
             "year": 2000,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/stories-from-the-city-stories-from-the-sea-demos\/1545008680",
             "appleMusicID": "1545008680",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-313-PJ-Harvey-Stories-From-The-City.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/56\/8c\/48\/568c4809-9978-28cd-68f4-fa1a124ab9f7\/20UMGIM74532.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 314,
@@ -2826,7 +2826,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/one-in-a-million\/1579610453",
             "appleMusicID": "1579610453",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-314-Aaliyah-One-In-A-Million.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/c2\/00\/43\/c2004382-02b0-c715-80e2-974252589883\/194690589874_cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 315,
@@ -2835,7 +2835,7 @@
             "year": 2018,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/el-mal-querer\/1436309944",
             "appleMusicID": "1436309944",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-315-Rosalia-_El-Mal-Querer_.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/2c\/55\/e1\/2c55e13f-15d8-1c7c-1826-c5fa55deaa8f\/886447217139.jpg\/600x600bb.jpg"
         },
         {
             "rank": 316,
@@ -2844,7 +2844,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-who-sell-out-super-deluxe\/1550182151",
             "appleMusicID": "1550182151",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-316-The-Who-The-Who-Sell-Out.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/4e\/bf\/f8\/4ebff81f-68fa-4cda-2f4d-5fdd4c211529\/20UM1IM17971.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 317,
@@ -2853,7 +2853,7 @@
             "year": 1958,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/lady-in-satin\/1689286255",
             "appleMusicID": "1689286255",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-317-Billie-Holiday-Lady-in-Satin.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/d0\/98\/1d\/d0981d7a-51fe-0992-053f-e71ecdb7573f\/196871175012.jpg\/600x600bb.jpg"
         },
         {
             "rank": 318,
@@ -2862,7 +2862,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-velvet-rope-deluxe-edition\/1646557266",
             "appleMusicID": "1646557266",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-318-Janet-Jackson-Velvet-Rope.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/21\/ba\/cf\/21bacf43-5878-e76b-e018-ca936a8243a7\/22UMGIM92303.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 319,
@@ -2871,7 +2871,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-stone-roses-remastered\/322969529",
             "appleMusicID": "322969529",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-319-The-Stone-Roses-The-Stone-Roses.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features115\/v4\/de\/bd\/71\/debd715a-d49b-1ec8-6b4d-bf3f25e0e90b\/dj.rldpqukx.jpg\/600x600bb.jpg"
         },
         {
             "rank": 320,
@@ -2880,7 +2880,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/los-angeles\/267023686",
             "appleMusicID": "267023686",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-320-X-Los-Angeles.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features115\/v4\/3c\/b0\/ee\/3cb0ee21-079f-8d58-1157-726dc85ea117\/dj.dkfjlgob.jpg\/600x600bb.jpg"
         },
         {
             "rank": 321,
@@ -2889,7 +2889,7 @@
             "year": 2019,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/norman-fucking-rockwell\/1474669063",
             "appleMusicID": "1474669063",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-321-Lana-Del-Rey-Norman-Fucking-Rockwell.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/c6\/5f\/b9\/c65fb9eb-da2f-89a9-b640-2fff1fc3a660\/19UMGIM61350.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 322,
@@ -2898,7 +2898,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/from-elvis-in-memphis\/1138094621",
             "appleMusicID": "1138094621",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-322-Elivs-Presley-From-Elvis-in-Memphis.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/45\/9d\/ee\/459deedc-c071-0f30-0d1c-18746dc18abc\/886445944754.jpg\/600x600bb.jpg"
         },
         {
             "rank": 323,
@@ -2907,7 +2907,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sandinista\/684746326",
             "appleMusicID": "684746326",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-323-The-Clash-Sandinista.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/01\/d2\/ad\/01d2ad5f-21b1-fa56-251a-efc29063b361\/886443566347.jpg\/600x600bb.jpg"
         },
         {
             "rank": 324,
@@ -2916,7 +2916,7 @@
             "year": 2002,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/a-rush-of-blood-to-the-head\/1122775993",
             "appleMusicID": "1122775993",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-324-Coldplay-A-Rush-of-Blood-to-the-Head.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/b9\/b4\/2a\/b9b42ad1-1e25-5096-da43-497a247e69a3\/190295978051.jpg\/600x600bb.jpg"
         },
         {
             "rank": 325,
@@ -2925,7 +2925,7 @@
             "year": 1993,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-325-Jerry-Lee-Lewis-All-Killer-No-Filler.jpg"
+            "imageURL": null
         },
         {
             "rank": 326,
@@ -2934,7 +2934,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/dirty-mind\/214145168",
             "appleMusicID": "214145168",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-326-Prince-Dirty-Mind.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/19\/30\/56\/mzi.oztizcwu.jpg\/600x600bb.jpg"
         },
         {
             "rank": 327,
@@ -2943,7 +2943,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/live-at-leeds-deluxe-edition-2001-remaster\/1440859591",
             "appleMusicID": "1440859591",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-327-The-Who-Live-at-Leeds.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/68\/25\/88\/68258891-c9c0-9cf3-dbc9-612d7503e27f\/00602537945719.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 328,
@@ -2952,7 +2952,7 @@
             "year": 2013,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/modern-vampires-of-the-city\/613184430",
             "appleMusicID": "613184430",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-328-Vampire-Weekend-Modern-Vampires-in-the-City.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/68\/69\/8d\/68698df4-e9f8-e57e-8dbe-a05c5bb2893e\/634904055653.png\/600x600bb.jpg"
         },
         {
             "rank": 329,
@@ -2961,7 +2961,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/endtroducing\/1660485817",
             "appleMusicID": "1660485817",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-329-DJ-Shadow-Endtroducing.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/0d\/14\/6d\/0d146d5c-44c5-22e2-c596-2242180f4774\/5400863103361_cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 330,
@@ -2970,7 +2970,7 @@
             "year": 2019,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/african-giant\/1471446047",
             "appleMusicID": "1471446047",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2019\/11\/burna-boy-african-giant.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/ac\/4c\/e3\/ac4ce34b-c2cd-a057-e049-b0914c51be1a\/075679849304.jpg\/600x600bb.jpg"
         },
         {
             "rank": 331,
@@ -2979,7 +2979,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/like-a-prayer\/83448003",
             "appleMusicID": "83448003",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-331-Madonna-Like-A-Prayer.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/20\/3c\/f5\/203cf53d-689e-528f-29d7-ba33758254aa\/mzi.rotbotfl.jpg\/600x600bb.jpg"
         },
         {
             "rank": 332,
@@ -2988,7 +2988,7 @@
             "year": 1956,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/elvis-presley\/671019373",
             "appleMusicID": "671019373",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-332-Elvis-Presley-Elvis-Presley.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/c2\/21\/a8\/c221a818-bc9f-675a-cecb-7dbc3bbe17a4\/886444095242.jpg\/600x600bb.jpg"
         },
         {
             "rank": 333,
@@ -2997,7 +2997,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/still-bill\/989376986",
             "appleMusicID": "989376986",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-333-bill-withers-Still-Bill.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/a3\/a6\/89\/a3a68964-ea23-9fa1-d123-eb9728997231\/886445193213.jpg\/600x600bb.jpg"
         },
         {
             "rank": 334,
@@ -3006,7 +3006,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/abraxas\/871146591",
             "appleMusicID": "871146591",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-334-Santana-Abraxas.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/30\/03\/7f\/30037fd6-3292-1806-c806-5341391c9aac\/886444593038.jpg\/600x600bb.jpg"
         },
         {
             "rank": 335,
@@ -3015,7 +3015,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-basement-tapes\/309065794",
             "appleMusicID": "309065794",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-335-Bob-Dylan-and-the-Band-the-Basement-Tapes.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/2f\/15\/50\/2f155072-e267-6bd5-befb-bf33e79a931c\/dj.ejeaqdvh.jpg\/600x600bb.jpg"
         },
         {
             "rank": 336,
@@ -3024,7 +3024,7 @@
             "year": 1982,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/avalon\/723875837",
             "appleMusicID": "723875837",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-336-Roxy-Music-AVALON.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/72\/ec\/3b\/72ec3b11-1060-be9d-1927-ddc611609be0\/13UABIM59240.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 337,
@@ -3033,7 +3033,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/john-wesley-harding\/181457097",
             "appleMusicID": "181457097",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-337-bob-dylan-john-wesley-harding.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/2e\/90\/ac\/2e90ac6d-c8e9-0f42-8852-af968be471dd\/mzi.uchoqyha.jpg\/600x600bb.jpg"
         },
         {
             "rank": 338,
@@ -3042,7 +3042,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/another-green-world\/724357753",
             "appleMusicID": "724357753",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-338-Brian-Eno-Another-Green-World.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/a4\/fe\/b1\/a4feb15b-126f-ce68-c6a0-a525005eb8e8\/13UABIM29259.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 339,
@@ -3051,7 +3051,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rhythm-nation-1814\/1440838561",
             "appleMusicID": "1440838561",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-339-Janet-Jackson-Rhythm-Nation-1814.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/5c\/06\/a5\/5c06a5fc-6424-25e4-37c4-da5a9a18dd8a\/00602547592378.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 340,
@@ -3060,7 +3060,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/doggystyle-30th-anniversary-edition\/1710796796",
             "appleMusicID": "1710796796",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/340-snoop-dogg-doggystyle.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/8b\/5b\/7e\/8b5b7e96-a8c6-53b5-a652-97cb1a47bc17\/617513821833_cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 341,
@@ -3069,7 +3069,7 @@
             "year": 1993,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/siamese-dream\/721207206",
             "appleMusicID": "721207206",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-341-The-Smashing-Pumpkins-Siamese-Dream.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/3a\/dc\/08\/3adc08b0-e98c-b5dd-943e-a37c7ed06205\/13UABIM03615.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 342,
@@ -3078,7 +3078,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/let-it-be-2021-super-deluxe\/1582541991",
             "appleMusicID": "1582541991",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-342-The-Beatles-Let-It-Be.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/5f\/ff\/9a\/5fff9a6a-bb13-6507-5e68-2793ef798834\/21UMGIM61121.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 343,
@@ -3087,7 +3087,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/greatest-hits\/212579326",
             "appleMusicID": "212579326",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-343-Sly-and-the-Family-Stone-Greatest-Hits.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/da\/10\/25\/da102506-5da5-2b7e-c4a2-7d54155c9455\/828767591025.jpg\/600x600bb.jpg"
         },
         {
             "rank": 344,
@@ -3096,7 +3096,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/funky-kingston\/1442853033",
             "appleMusicID": "1442853033",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-344-Toots-and-the-Maytals-Funky-Kingston.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/af\/93\/2e\/af932e55-0e47-035f-bdf5-27103e623404\/00602547748959.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 345,
@@ -3105,7 +3105,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-wild-the-innocent-the-e-street-shuffle\/186149850",
             "appleMusicID": "186149850",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-345-bruce-springsteen-The-Wild-the-Innocent-and-the-E-Street-Shuffle.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/d3\/44\/7d\/d3447d43-bb3e-477a-6de6-f27f616b0824\/074643243223.jpg\/600x600bb.jpg"
         },
         {
             "rank": 346,
@@ -3114,7 +3114,7 @@
             "year": 2013,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/am\/663097964",
             "appleMusicID": "663097964",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-346-Arctic-Monkeys-AM.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/cc\/0f\/2d\/cc0f2d02-5ff1-10e7-eea2-76863a55dbad\/887828031795.png\/600x600bb.jpg"
         },
         {
             "rank": 347,
@@ -3123,7 +3123,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/liquid-swords-expanded-edition\/1537029775",
             "appleMusicID": "1537029775",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-347-GZA-Liquid-Swords.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/7e\/dc\/fd\/7edcfd48-26be-76a1-152f-d88b79977ccb\/20UMGIM75114.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 348,
@@ -3132,7 +3132,7 @@
             "year": 2001,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/time-the-revelator\/1371729145",
             "appleMusicID": "1371729145",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-348-Gillian-Welch-Time-the-Revelator.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/b8\/b9\/fe\/b8b9fefa-15d2-d28c-2ba1-0baa143c60d1\/805147010345.jpg\/600x600bb.jpg"
         },
         {
             "rank": 349,
@@ -3141,7 +3141,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/kick-out-the-jams\/1018383064",
             "appleMusicID": "1018383064",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-349-MC5-Kick-out-the-Jams.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music1\/v4\/be\/9a\/ab\/be9aab76-0d5a-d3a4-d28d-8bc14eac5a56\/603497887590.jpg\/600x600bb.jpg"
         },
         {
             "rank": 350,
@@ -3150,7 +3150,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/music-of-my-mind\/1440858437",
             "appleMusicID": "1440858437",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-350-Stevie-Wonder-Music-of-My-Mind.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/c6\/a9\/05\/c6a9050c-338f-cd45-6d1e-75d9b2e1e85a\/00602537672905.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 351,
@@ -3159,7 +3159,7 @@
             "year": 2022,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sos\/1657869377",
             "appleMusicID": "1657869377",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2022\/12\/SZA-album-cover.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/bd\/3b\/a9\/bd3ba9fb-9609-144f-bcfe-ead67b5f6ab3\/196589564931.jpg\/600x600bb.jpg"
         },
         {
             "rank": 352,
@@ -3168,7 +3168,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-slim-shady-lp-expanded-edition\/1453196979",
             "appleMusicID": "1453196979",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-352-Eminem-The-Slim-Shady-LP.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/44\/d3\/01\/44d3016a-6747-25bf-8cd4-4c4fa5ced26f\/19UMGIM04260.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 353,
@@ -3177,7 +3177,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-cars\/1088527349",
             "appleMusicID": "1088527349",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-353-The-Cars-The-Cars.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/6b\/3c\/1d\/6b3c1d3e-46a3-d0ac-e386-c2e60c8c8f49\/mzm.hdqcumzx.jpg\/600x600bb.jpg"
         },
         {
             "rank": 354,
@@ -3186,7 +3186,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/germ-free-adolescents\/1607303718",
             "appleMusicID": "1607303718",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-354-X-Ray-Spex-Germfree-Adolescents.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/2e\/aa\/4b\/2eaa4bf6-af91-e5f9-a03a-37132b5f4c3e\/859753382280_cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 355,
@@ -3195,7 +3195,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/black-sabbath-remastered\/1438648677",
             "appleMusicID": "1438648677",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-355-Black-Sabbath-Black-Sabbath.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/6f\/4f\/3a\/6f4f3a7d-8bad-c8a9-c65f-c525170aa1ed\/0602537422630.jpg\/600x600bb.jpg"
         },
         {
             "rank": 356,
@@ -3204,7 +3204,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/gris-gris\/106225386",
             "appleMusicID": "106225386",
-            "imageURL": null
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/43\/05\/92\/4305923f-644f-9c6f-8774-54724b0f49ab\/mzi.pzhhpoen.jpg\/600x600bb.jpg"
         },
         {
             "rank": 357,
@@ -3213,7 +3213,7 @@
             "year": 1985,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rain-dogs-2023-remaster\/1695046955",
             "appleMusicID": "1695046955",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-357-Tom-Waits-Raindogs.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/f7\/6f\/43\/f76f4343-8432-d507-26d9-ba136541085b\/23UMGIM74399.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 358,
@@ -3222,7 +3222,7 @@
             "year": 2021,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sour-video-version\/1582274783",
             "appleMusicID": "1582274783",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2021\/12\/Olivia-Rodrigo-Sour.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/ce\/63\/06\/ce6306bb-5830-af8f-8ebd-4eb7d3c14e1e\/21UMGIM26092.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 359,
@@ -3231,7 +3231,7 @@
             "year": 1974,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/radio-city-remastered\/1443879203",
             "appleMusicID": "1443879203",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-359-Big-Star-Radio-City.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/89\/7f\/a0\/897fa0f2-e2ae-6234-80d8-ac6ccb2c33b9\/00888072315747.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 360,
@@ -3240,7 +3240,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/one-nation-under-a-groove-remastered-edition-bonus-tracks\/1180047913",
             "appleMusicID": "1180047913",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-360-Funkadelic-One-Nation-Under-a-Groove.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music71\/v4\/02\/a3\/f8\/02a3f892-f37d-51ae-a538-741ef9fa6ae0\/LM00105897.jpg\/600x600bb.jpg"
         },
         {
             "rank": 361,
@@ -3249,7 +3249,7 @@
             "year": 2006,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-black-parade\/1156310650",
             "appleMusicID": "1156310650",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-361-My-Chemical-Romance-The-Black-Parade.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/56\/99\/8a\/56998a1c-efe7-fdf0-2b1d-e2da88d8df52\/093624917724.jpg\/600x600bb.jpg"
         },
         {
             "rank": 362,
@@ -3258,7 +3258,7 @@
             "year": 1981,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/never-too-much\/190652453",
             "appleMusicID": "190652453",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-362-Luther-Vandross-Never-Too-Much.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/81\/41\/87\/81418780-b371-faa6-a3b5-5073be62a6ae\/mzi.mskephqn.jpg\/600x600bb.jpg"
         },
         {
             "rank": 363,
@@ -3267,7 +3267,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/mothership-connection\/1440837684",
             "appleMusicID": "1440837684",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-363-Parliament-Funk-MOTHER-SHIP.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/b3\/dc\/3a\/b3dc3af0-b044-6914-1cdf-2ba2c8b36169\/00602547748492.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 364,
@@ -3276,7 +3276,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/more-songs-about-buildings-and-food\/302108628",
             "appleMusicID": "302108628",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-364-Talking-Heads-More-songs-about-buildings-and-food.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/6a\/8b\/e7\/mzi.vbyfmxaz.jpg\/600x600bb.jpg"
         },
         {
             "rank": 365,
@@ -3285,7 +3285,7 @@
             "year": 2004,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/madvillainy\/887699504",
             "appleMusicID": "887699504",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-365-Madvillain-Madvillainy.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/1a\/c2\/1a\/1ac21a9d-3ffd-3f80-dc96-223622b50b5f\/Madvillainy.jpg\/600x600bb.jpg"
         },
         {
             "rank": 366,
@@ -3294,7 +3294,7 @@
             "year": 1976,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rocks\/1658654048",
             "appleMusicID": "1658654048",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-366-Aerosmith-Rocks.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/41\/cc\/1e\/41cc1e86-3f4e-f8f4-c525-67d4817167e6\/22UM1IM35690.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 367,
@@ -3303,7 +3303,7 @@
             "year": 2015,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/if-youre-reading-this-its-too-late\/1440839718",
             "appleMusicID": "1440839718",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-367-Drake-if-youre-reading-this-it_s-too-late.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/27\/9a\/8c\/279a8c66-9914-add2-9c7f-912f2946fb8a\/15UMGIM08570.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 368,
@@ -3312,7 +3312,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/all-things-must-pass-2014-remaster\/1666672128",
             "appleMusicID": "1666672128",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-368-George-Harrison-All-Things-Must-Pass.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/32\/2a\/f4\/322af42a-41fd-f52f-e1ee-dc7502bd4bba\/0602547025340.jpg\/600x600bb.jpg"
         },
         {
             "rank": 369,
@@ -3321,7 +3321,7 @@
             "year": 1995,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-infamous-25th-anniversary-expanded-edition\/1508621774",
             "appleMusicID": "1508621774",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-369-Mobb-Deep-The-Infamous.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/6a\/1e\/d9\/6a1ed9c0-1aba-f558-125d-364d6d6ade4f\/886448420774.jpg\/600x600bb.jpg"
         },
         {
             "rank": 370,
@@ -3330,7 +3330,7 @@
             "year": 2005,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/tha-carter-ii\/1440653393",
             "appleMusicID": "1440653393",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-370-Lil-Wayne-Tha-Carter-II.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/85\/f9\/1c\/85f91c0e-9665-837f-a772-e964a215b91f\/06UMGIM17275.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 371,
@@ -3339,7 +3339,7 @@
             "year": 1973,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-371-The-Temptations-Anthology.jpg"
+            "imageURL": null
         },
         {
             "rank": 372,
@@ -3348,7 +3348,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/cheap-thrills\/203773381",
             "appleMusicID": "203773381",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-372-Janis-Joplin-Big-Brother-and-the-Holding-Co-Cheap-Thrills.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/9c\/5c\/f3\/9c5cf3ff-b840-e1be-ee06-4d9220b36901\/074646578421.jpg\/600x600bb.jpg"
         },
         {
             "rank": 373,
@@ -3357,7 +3357,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/hot-buttered-soul\/1440941776",
             "appleMusicID": "1440941776",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-373-Isaac-Hayes-Hot-Buttered-Soul.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/63\/08\/65\/630865dc-ee73-cb3e-c3b3-6e0d27d06789\/00888072013339.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 374,
@@ -3366,7 +3366,7 @@
             "year": 1961,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/king-of-the-delta-blues-singers\/157432232",
             "appleMusicID": "157432232",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-374-Robert-Johnson-King-of-the-Delta-Blues.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/3c\/74\/0d\/3c740deb-0293-4184-a66d-5176b9e872a4\/mzi.scyemciw.jpg\/600x600bb.jpg"
         },
         {
             "rank": 375,
@@ -3375,7 +3375,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/dookie-30th-anniversary-deluxe-edition\/1702070738",
             "appleMusicID": "1702070738",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-375-green-day-dookie.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/5d\/b8\/1e\/5db81e1c-62b2-41ae-da6b-52879bf2334d\/093624850212.jpg\/600x600bb.jpg"
         },
         {
             "rank": 376,
@@ -3384,7 +3384,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/in-the-aeroplane-over-the-sea\/1706256141",
             "appleMusicID": "1706256141",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-376-Neutral-Milk-Hotel-In-the-Aeroplane-Over-the-Sea.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/73\/87\/92\/7387923f-063f-f0c3-d529-2779859c178b\/508831.jpg\/600x600bb.jpg"
         },
         {
             "rank": 377,
@@ -3393,7 +3393,7 @@
             "year": 2003,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/fever-to-tell\/1440916724",
             "appleMusicID": "1440916724",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-377-Yeah-Yeah-Yeahs-Fever-to-Tell.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/1c\/9b\/9a\/1c9b9a3e-099c-b3d6-c3ce-4a270a2d221c\/17UM1IM27260.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 378,
@@ -3402,7 +3402,7 @@
             "year": 1983,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/run-dmc\/550370521",
             "appleMusicID": "550370521",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-378-Run-DMC-Run-DMC.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/v4\/57\/1b\/80\/571b80fa-5749-da3c-d518-83e369bf43ce\/888880754950.jpg\/600x600bb.jpg"
         },
         {
             "rank": 379,
@@ -3411,7 +3411,7 @@
             "year": 1981,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/moving-pictures-40th-anniversary-super-deluxe\/1608979166",
             "appleMusicID": "1608979166",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-379-rush-moving-pictures.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/9e\/84\/e9\/9e84e984-e923-de7d-16e5-982b2cdd1d98\/21UMGIM68387.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 380,
@@ -3420,7 +3420,7 @@
             "year": 1959,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/mingus-ah-um-legacy-edition\/315947000",
             "appleMusicID": "315947000",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-380-Charles-Mingus-Mingus-Ah-Um.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/85\/f3\/ef\/mzi.etlgbitd.jpg\/600x600bb.jpg"
         },
         {
             "rank": 381,
@@ -3429,7 +3429,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pronounced-leh-nerd-skin-nerd\/1440838012",
             "appleMusicID": "1440838012",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-381-Lynyrd-Skynyrd-pronounced-lynyrd-skynyrd.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/57\/00\/f3\/5700f331-2d06-7f5d-cb98-43970fd52874\/14UMGIM00860.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 382,
@@ -3438,7 +3438,7 @@
             "year": 2015,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/currents\/1440838039",
             "appleMusicID": "1440838039",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-382-Tame-Impala-Currents.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/a8\/2e\/b4\/a82eb490-f30a-a321-461a-0383c88fec95\/15UMGIM23316.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 383,
@@ -3447,7 +3447,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/mezzanine-deluxe\/1428684976",
             "appleMusicID": "1428684976",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-383-Massive-Attack-Mezzanine.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/8a\/c1\/04\/8ac104fb-d37e-1433-5d2e-805710d7a7c4\/00602567930983.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 384,
@@ -3456,7 +3456,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-kinks-are-the-village-green-preservation-society\/1422691058",
             "appleMusicID": "1422691058",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-384-The-kinks-_the-kinks-are-village-green-preservation-society.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/5e\/07\/80\/5e0780c2-7a2f-1adc-23c9-ac969a27c0e6\/5414939544774.jpg\/600x600bb.jpg"
         },
         {
             "rank": 385,
@@ -3465,7 +3465,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rocket-to-russia\/847962534",
             "appleMusicID": "847962534",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-385-ramones-rocket-to-russia.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music6\/v4\/c0\/b4\/0b\/c0b40bfe-f81f-0729-eba2-4440ac324f53\/603497909582.jpg\/600x600bb.jpg"
         },
         {
             "rank": 386,
@@ -3474,7 +3474,7 @@
             "year": 2006,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/donuts\/108233171",
             "appleMusicID": "108233171",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-386-jdilla-donuts.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/63\/d3\/c5\/63d3c537-ac30-86e7-8e69-8a03a5346209\/792.jpg\/600x600bb.jpg"
         },
         {
             "rank": 387,
@@ -3483,7 +3483,7 @@
             "year": 2007,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/in-rainbows\/1109714933",
             "appleMusicID": "1109714933",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-387-Radiohead-In-Rainbows.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/dd\/50\/c7\/dd50c790-99ac-d3d0-5ab8-e3891fb8fd52\/634904032463.png\/600x600bb.jpg"
         },
         {
             "rank": 388,
@@ -3492,7 +3492,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/young-gifted-and-black\/934216863",
             "appleMusicID": "934216863",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-388-Aretha-Franklin-Young-Gifted-and-Black.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/6c\/f0\/0e\/6cf00ef2-2eaa-5f77-20b6-57c21016e987\/603497896363.jpg\/600x600bb.jpg"
         },
         {
             "rank": 389,
@@ -3501,7 +3501,7 @@
             "year": 2005,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-emancipation-of-mimi\/1476731879",
             "appleMusicID": "1476731879",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-389-Mariah-Carey-Emancipation-of-Mimi.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/34\/66\/31\/346631f0-dc0e-500f-7cb8-537e7523e022\/15UMGIM78299.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 390,
@@ -3510,7 +3510,7 @@
             "year": 1988,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/surfer-rosa-remastered\/1027465077",
             "appleMusicID": "1027465077",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-390-Pixies-SURFERROSA.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/68\/b7\/c0\/68b7c018-dc15-f44a-2611-be10237fc9a5\/652637080308.png\/600x600bb.jpg"
         },
         {
             "rank": 391,
@@ -3519,7 +3519,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/kaleidoscope-expanded-edition\/1712490712",
             "appleMusicID": "1712490712",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-391-Kelis-Kaleidoscope.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/58\/f8\/25\/58f82517-314d-b53f-ed75-8669e6ef88dc\/5400863044961_cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 392,
@@ -3528,7 +3528,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/proud-mary-the-best-of-ike-and-tina-turner\/724157961",
             "appleMusicID": "724157961",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-392-ike-and-tina-turner-Proud-Mary-The-Best-of-Ike-and-Tina-Turner.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/39\/cd\/b3\/39cdb32c-b01f-e30a-5631-80b99100e1e0\/13ULAIM49177.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 393,
@@ -3537,7 +3537,7 @@
             "year": 2014,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/1989-taylors-version-deluxe\/1713845538",
             "appleMusicID": "1713845538",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-393-Taylor-Swift-1989.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/8e\/35\/6c\/8e356cc2-0be4-b83b-d29e-b578623df2ac\/23UM1IM34052.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 394,
@@ -3546,7 +3546,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/diana\/1443159760",
             "appleMusicID": "1443159760",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-394-Diana-Ross-Diana.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/aa\/87\/1c\/aa871c20-95be-38bd-97e3-ecfeb8ec404b\/15UMGIM06551.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 395,
@@ -3555,7 +3555,7 @@
             "year": 2014,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/black-messiah\/950764300",
             "appleMusicID": "950764300",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-395-D_Angelo-Black-Messiah.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/01\/38\/24\/01382463-de8c-2a33-f8fe-fb3a008dfc87\/886444977449.jpg\/600x600bb.jpg"
         },
         {
             "rank": 396,
@@ -3564,7 +3564,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/something-anything\/1084074389",
             "appleMusicID": "1084074389",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-396-Todd-Rungren-Something_Anything_.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/bd\/c0\/45\/bdc045ff-2b04-4950-bb63-b7fc03fec6ea\/603497884162.jpg\/600x600bb.jpg"
         },
         {
             "rank": 397,
@@ -3573,7 +3573,7 @@
             "year": 2019,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/when-we-all-fall-asleep-where-do-we-go\/1450695723",
             "appleMusicID": "1450695723",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-397-billie-eilish-when-we-all-fall-asleep-where-do-we-go.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/1a\/37\/d1\/1a37d1b1-8508-54f2-f541-bf4e437dda76\/19UMGIM05028.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 398,
@@ -3582,7 +3582,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-raincoats\/371773193",
             "appleMusicID": "371773193",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-398-The-Raincoats-The-Raincoats.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/df\/04\/09\/mzi.dnqicgwz.jpg\/600x600bb.jpg"
         },
         {
             "rank": 399,
@@ -3591,7 +3591,7 @@
             "year": 2004,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/smile\/29164695",
             "appleMusicID": "29164695",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-399-brian-wilsons-smile.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/y2004\/m11\/d09\/h00\/s06.ceiowlmw.jpg\/600x600bb.jpg"
         },
         {
             "rank": 400,
@@ -3600,7 +3600,7 @@
             "year": 1981,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/beauty-and-the-beat\/1440843867",
             "appleMusicID": "1440843867",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-400-The-Go-Gos-Beauty-and-the-Beat.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/10\/24\/fc\/1024fcc2-7cbe-fcee-90ce-f906292f9832\/06UMGIM00679.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 401,
@@ -3609,7 +3609,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blondie-bonus-tracks-edition-2001-remaster\/724506061",
             "appleMusicID": "724506061",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-401-Blondie-Blondie.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/69\/d8\/c6\/69d8c628-db97-25d7-289d-5a367c04d58b\/00724353359652.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 402,
@@ -3618,7 +3618,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/expensive-shit-ep\/598098820",
             "appleMusicID": "598098820",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-402-Fela-Kuti-Expensive-Shit.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/0e\/4f\/b9\/0e4fb969-30de-5143-4202-76d44eb59540\/cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 403,
@@ -3627,7 +3627,7 @@
             "year": 2000,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/supreme-clientele\/190401592",
             "appleMusicID": "190401592",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-403-Ghostface-Killah-Supreme-Clientele.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/29\/26\/f8\/2926f8e4-9955-f417-31be-d18869ea75a8\/mzi.qlmvzdnk.jpg\/600x600bb.jpg"
         },
         {
             "rank": 404,
@@ -3636,7 +3636,7 @@
             "year": 1986,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/rapture\/1018520424",
             "appleMusicID": "1018520424",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-404-Anita-Baker-Rapture.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/64\/ab\/bc\/64abbc66-b724-1ca1-68e5-afafbb2b9f2e\/603497888283.jpg\/600x600bb.jpg"
         },
         {
             "rank": 405,
@@ -3645,7 +3645,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/psychedelic-nuggets-the-60s-rarities-collection\/823611187",
             "appleMusicID": "823611187",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-405-Various-Nuggets-Original-artyfacts-from-the-First-Psychedelic-Era.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/v4\/be\/ca\/2d\/beca2ded-8062-442f-af96-825176f4a2c9\/itunes_PsychedelicNuggets_The60sRaritiesCollection.jpg\/600x600bb.jpg"
         },
         {
             "rank": 406,
@@ -3654,7 +3654,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/69-love-songs\/15224879",
             "appleMusicID": "15224879",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-406-Magnetic-Fields-69-Love-Songs.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/fb\/9a\/9a\/fb9a9ac4-516b-1242-0f59-55dbb39f60c5\/169_MagFields_69LS_2500px.jpg\/600x600bb.jpg"
         },
         {
             "rank": 407,
@@ -3663,7 +3663,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/everybody-knows-this-is-nowhere\/1015769589",
             "appleMusicID": "1015769589",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-407-Neil-Young-Everybody-Knows-This-Is-Nowhere.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/86\/05\/0d\/86050dc2-b99f-9e0e-1af5-549d279b7638\/093624924739.jpg\/600x600bb.jpg"
         },
         {
             "rank": 408,
@@ -3672,7 +3672,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ace-of-spades\/1614256828",
             "appleMusicID": "1614256828",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-408-Motorhead-Ace-of-Spades.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/12\/bd\/5f\/12bd5f42-768d-bdae-c346-c199d1568a09\/4050538804966.jpg\/600x600bb.jpg"
         },
         {
             "rank": 409,
@@ -3681,7 +3681,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/workingmans-dead\/663696329",
             "appleMusicID": "663696329",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-409-Grateful-Dead-Workingmans-Dead.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/79\/cc\/eb\/79ccebad-c071-ad53-2aa7-aeef95f8f4bf\/603497920983.jpg\/600x600bb.jpg"
         },
         {
             "rank": 410,
@@ -3690,7 +3690,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/wild-honey\/1443213067",
             "appleMusicID": "1443213067",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-410-the-beach-boys-wild-honey.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/70\/cd\/24\/70cd2429-509d-916a-89e5-37fc493f2f28\/13UABIM52542.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 411,
@@ -3699,7 +3699,7 @@
             "year": 2001,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/love-and-theft\/552413840",
             "appleMusicID": "552413840",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-411-Bob-Dylan-Love-and-Theft.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/v4\/bd\/4d\/56\/bd4d56c3-6dbc-8e24-c0c4-c144331d6ff7\/886443614376.jpg\/600x600bb.jpg"
         },
         {
             "rank": 412,
@@ -3708,7 +3708,7 @@
             "year": 1965,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/going-to-a-go-go\/1469577666",
             "appleMusicID": "1469577666",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-412-Smokey-Robinson-The-Miracles-Going-To-a-Go-Go-1.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/b9\/e3\/58\/b9e35838-8084-06f7-8ae4-fb76e1160bcb\/13UAAIM44691.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 413,
@@ -3717,7 +3717,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/cosmos-factory\/1440948745",
             "appleMusicID": "1440948745",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-413-CCR-Cosmos-Factory.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/f3\/81\/ca\/f381ca2b-0779-4102-2c64-8b2563eedb96\/00888072355996.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 414,
@@ -3726,7 +3726,7 @@
             "year": 1979,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/risqu\u00e9-2018-remaster\/1442986865",
             "appleMusicID": "1442986865",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-414-Chic-Risque.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/fd\/97\/0c\/fd970c67-3f13-a3f4-3eba-adba8867b762\/603497853571.jpg\/600x600bb.jpg"
         },
         {
             "rank": 415,
@@ -3735,7 +3735,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/look-ka-py-py\/159362708",
             "appleMusicID": "159362708",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-415-Meters-Looka-Py-Py.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/f9\/d4\/78\/mzi.cratrfmd.jpg\/600x600bb.jpg"
         },
         {
             "rank": 416,
@@ -3744,7 +3744,7 @@
             "year": 1999,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/things-fall-apart\/1440632803",
             "appleMusicID": "1440632803",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-416-The-Roots-Things-Fall-Apart.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/74\/1d\/df\/741ddf4b-a124-16f4-60f3-03e03f291eab\/06UMGIM02261.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 417,
@@ -3753,7 +3753,7 @@
             "year": 1959,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-shape-of-jazz-to-come\/50234787",
             "appleMusicID": "50234787",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-417-Ornette-Coleman-the-Shape-of-jazz-to-come.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/ec\/fe\/82\/ecfe82b7-b821-b318-17ad-512b9cd1717b\/s06.afpdcbhn.jpg\/600x600bb.jpg"
         },
         {
             "rank": 418,
@@ -3762,7 +3762,7 @@
             "year": 1985,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/brothers-in-arms-remastered-1996\/1565391787",
             "appleMusicID": "1565391787",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-418-Dire-Straits-Brothers-in-Arms.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e6\/5c\/4b\/e65c4bc3-c707-7502-bff1-550815956bc6\/21UMGIM32483.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 419,
@@ -3771,7 +3771,7 @@
             "year": 2011,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/chief\/721280109",
             "appleMusicID": "721280109",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-419-Eric-Church-Chief.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/69\/76\/77\/69767702-ea47-d219-a13c-0f51e19e6ccb\/13UABIM59426.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 420,
@@ -3780,7 +3780,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/thats-the-way-of-the-world\/532975789",
             "appleMusicID": "532975789",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-420-Earth-Wind-and-Fire-Thats-The-Way-of-The-World.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music49\/v4\/1d\/86\/bc\/1d86bc2d-1007-3b47-2652-f4a58fb0eaa0\/dj.amgioild.jpg\/600x600bb.jpg"
         },
         {
             "rank": 421,
@@ -3789,7 +3789,7 @@
             "year": 2005,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/arular\/1450124269",
             "appleMusicID": "1450124269",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-421-MIA-Arular.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/5c\/e3\/0d\/5ce30d48-d43e-e3e6-ac46-9e9aa449731f\/634904018658.png\/600x600bb.jpg"
         },
         {
             "rank": 422,
@@ -3798,7 +3798,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/lets-get-it-on-remastered-2003\/1442835298",
             "appleMusicID": "1442835298",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-422-Marvin-Gaye-Lets-Get-it-On.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/dc\/fa\/3a\/dcfa3a34-a2eb-8144-7fda-b978b7afbe19\/06UMGIM11335.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 423,
@@ -3807,7 +3807,7 @@
             "year": 1997,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/i-can-hear-the-heart-beating-as-one-25th-anniversary\/1617046223",
             "appleMusicID": "1617046223",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-423-Yo-La-Tengo-I-Can-Hear-the-Heart-Beating-As-One.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/ce\/46\/27\/ce462751-38c2-4474-18a7-d804c1885740\/191401187756.png\/600x600bb.jpg"
         },
         {
             "rank": 424,
@@ -3816,7 +3816,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/odelay-deluxe-edition\/1453197774",
             "appleMusicID": "1453197774",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-424-Beck-ODELAY-HR.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/5b\/bd\/e5\/5bbde5af-e430-2b74-1980-00bd784d8a27\/00602577519956.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 425,
@@ -3825,7 +3825,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/paul-simon-bonus-tracks-edition\/380588824",
             "appleMusicID": "380588824",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-425-Paul-Simon-Paul-Simon.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/39\/e8\/5c\/39e85c62-83f6-cced-9a56-122f2361566e\/dj.jicohfwb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 426,
@@ -3834,7 +3834,7 @@
             "year": 1988,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/lucinda-williams-deluxe-edition\/761048202",
             "appleMusicID": "761048202",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-426-Lucinda-Williams-Lucinda-Williams.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/47\/8b\/8e\/478b8e7b-182a-258e-eded-1fc6e88f1341\/886444344852.jpg\/600x600bb.jpg"
         },
         {
             "rank": 427,
@@ -3843,7 +3843,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/call-me\/1196508713",
             "appleMusicID": "1196508713",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-427-Al-Green-Call-Me.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/e4\/ee\/c4\/e4eec491-99aa-b54b-2de5-388b298555dc\/886446283784.jpg\/600x600bb.jpg"
         },
         {
             "rank": 428,
@@ -3852,7 +3852,7 @@
             "year": 1985,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/new-day-rising\/515394889",
             "appleMusicID": "515394889",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-428-Husker-Du-New-Day-Rising.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music4\/v4\/25\/3b\/42\/253b425d-a323-4f44-4a26-087c35d9941a\/dj.vmxuycmg.jpg\/600x600bb.jpg"
         },
         {
             "rank": 429,
@@ -3861,7 +3861,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/reach-out\/1443092485",
             "appleMusicID": "1443092485",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-429-Four-Tops-Reach-Out.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/97\/4c\/58\/974c5833-8190-ced8-f2d0-3ca9bd270248\/14UMGIM28821.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 430,
@@ -3870,7 +3870,7 @@
             "year": 2022,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/un-verano-sin-ti\/1622045624",
             "appleMusicID": "1622045624",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2022\/12\/bad-bunny-un-verano-sin-ti-1.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/3e\/04\/eb\/3e04ebf6-370f-f59d-ec84-2c2643db92f1\/196626945068.jpg\/600x600bb.jpg"
         },
         {
             "rank": 431,
@@ -3879,7 +3879,7 @@
             "year": 1984,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/how-will-the-wolf-survive\/309581839",
             "appleMusicID": "309581839",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-431-Los-Lobos-How-Will-the-Wolf-Survive.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/57\/da\/73\/57da735e-3512-c0a8-0b94-356d4a76820a\/mzi.bclvaczz.jpg\/600x600bb.jpg"
         },
         {
             "rank": 432,
@@ -3888,7 +3888,7 @@
             "year": 2004,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/confessions-expanded-edition\/386153476",
             "appleMusicID": "386153476",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-432-Usher-Confessions.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/02\/c6\/e1\/02c6e1cd-8d57-97b4-6ef1-77d2be004509\/mzi.sjrqsmrq.jpg\/600x600bb.jpg"
         },
         {
             "rank": 433,
@@ -3897,7 +3897,7 @@
             "year": 2007,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sound-of-silver\/742432549",
             "appleMusicID": "742432549",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-433-LCD-Soundsystem-Sound-of-Silver.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/fb\/fe\/a5\/fbfea51a-0130-d557-c1f4-9e5e98b7bab8\/094638511359.jpg\/600x600bb.jpg"
         },
         {
             "rank": 434,
@@ -3906,7 +3906,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/crooked-rain-crooked-rain\/1589187959",
             "appleMusicID": "1589187959",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-434-Pavement-CROOKED-RAIN.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/47\/6b\/1a\/476b1afc-452c-909e-a70f-15b055f5e6dc\/744861007937.png\/600x600bb.jpg"
         },
         {
             "rank": 435,
@@ -3915,7 +3915,7 @@
             "year": 1987,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/actually-2018-remaster\/1645128416",
             "appleMusicID": "1645128416",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-435-Pet-Shop-Boys-Actually.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/37\/95\/1a\/37951a3d-6f9b-b5fc-fdac-e4818029ba00\/5054197358579.jpg\/600x600bb.jpg"
         },
         {
             "rank": 436,
@@ -3924,7 +3924,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/all-eyez-on-me\/1588480719",
             "appleMusicID": "1588480719",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-436-Tupac-all-Eyez-on-Me.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/33\/84\/fc\/3384fc51-1eeb-e78f-2770-14844fcdd3b5\/21UM1IM16262.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 437,
@@ -3933,7 +3933,7 @@
             "year": 2005,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/demon-days\/850571319",
             "appleMusicID": "850571319",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2023\/12\/gorillaz-demon-days.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/1c\/0f\/81\/1c0f818a-e458-dd84-6f1b-ccbdf5fe14d6\/825646291045.jpg\/600x600bb.jpg"
         },
         {
             "rank": 438,
@@ -3942,7 +3942,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/parklife\/699665183",
             "appleMusicID": "699665183",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-438-Blur-Parklife.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/8a\/71\/66\/8a71664b-3baa-537b-e008-b32d86da27bc\/5099997227755.jpg\/600x600bb.jpg"
         },
         {
             "rank": 439,
@@ -3951,7 +3951,7 @@
             "year": 1970,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sex-machine\/1442983352",
             "appleMusicID": "1442983352",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-439-James-Brown-Sex-Machine.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/17\/8b\/05\/178b05de-5855-0136-9827-a0e8a6ccf3db\/00602547021656.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 440,
@@ -3960,7 +3960,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/coal-miners-daughter\/1442878759",
             "appleMusicID": "1442878759",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-440-Loretta-Lynn-Coal-Miner_s-Daughter.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/79\/71\/36\/7971368c-9138-1070-44fe-31f5fd821ba7\/16UMGIM07485.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 441,
@@ -3969,7 +3969,7 @@
             "year": 2007,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blackout-deluxe-edition\/521738882",
             "appleMusicID": "521738882",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-441-Britney-Spears-Blackout.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/05\/48\/eb\/0548eb35-348c-a4c9-d245-8003d81214a6\/884977724936.jpg\/600x600bb.jpg"
         },
         {
             "rank": 442,
@@ -3978,7 +3978,7 @@
             "year": 2015,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/beauty-behind-the-madness\/1440826239",
             "appleMusicID": "1440826239",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-442-Weeknd-beauty-behind-the-madness.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/40\/cd\/1a\/40cd1a65-7948-eb96-74c6-1c4b3497456c\/15UMGIM36513.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 443,
@@ -3987,7 +3987,7 @@
             "year": 1980,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/scary-monsters-and-super-creeps-2017-remaster\/1347896167",
             "appleMusicID": "1347896167",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-443-David-Bowie-Scary-Monsters.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/71\/fe\/14\/71fe14df-5d77-9d69-2968-c38b6bfa82a4\/190295842598.jpg\/600x600bb.jpg"
         },
         {
             "rank": 444,
@@ -3996,7 +3996,7 @@
             "year": 2005,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/extraordinary-machine\/153432152",
             "appleMusicID": "153432152",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-444-Fiona-Apple-Extraordinary-Machine.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/4e\/3e\/09\/4e3e09d9-6eff-5ba2-2af5-87f3eb39af04\/696998668324.jpg\/600x600bb.jpg"
         },
         {
             "rank": 445,
@@ -4005,7 +4005,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/close-to-the-edge\/1049014094",
             "appleMusicID": "1049014094",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-445-yes-Close-to-the-Edge.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music6\/v4\/94\/d8\/a2\/94d8a2bf-797b-c9d2-1602-671c0b79a765\/603497886074.jpg\/600x600bb.jpg"
         },
         {
             "rank": 446,
@@ -4014,7 +4014,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/journey-in-satchidananda\/1440719294",
             "appleMusicID": "1440719294",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-446-Alice-Coltrane-Journey-in-Satchidanada.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/af\/5c\/40\/af5c40a1-54b1-855d-3da2-f875efbd8372\/06UMGIM04169.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 447,
@@ -4023,7 +4023,7 @@
             "year": 2018,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/x-100pre\/1447554595",
             "appleMusicID": "1447554595",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-447-bad-bunny-X100pre.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/cf\/3a\/db\/cf3adbe6-8ea1-f60f-60fd-713eefda3962\/193483317984.jpg\/600x600bb.jpg"
         },
         {
             "rank": 448,
@@ -4032,7 +4032,7 @@
             "year": 1966,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/complete-unbelievable-the-otis-redding-dictionary\/1146946661",
             "appleMusicID": "1146946661",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-448-Otis-Redding-Dictionary-of-Soul.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/d1\/46\/df\/d146dfe7-f459-e9e1-952f-8a55c4fd9a51\/603497872299.jpg\/600x600bb.jpg"
         },
         {
             "rank": 449,
@@ -4041,7 +4041,7 @@
             "year": 2003,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/elephant-deluxe\/1675379752",
             "appleMusicID": "1675379752",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-449-WhiteStripesELEPHANT.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/48\/b5\/b9\/48b5b90e-ba1e-08ff-1217-9e479afdad5d\/196589901750.jpg\/600x600bb.jpg"
         },
         {
             "rank": 450,
@@ -4050,7 +4050,7 @@
             "year": 1971,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ram-archive-collection-2012-remaster\/1434073187",
             "appleMusicID": "1434073187",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-450-Paul-mcCartney-RAM.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/6e\/6b\/dd\/6e6bdd7c-ae99-8745-5845-4256fee2ca5a\/00602577008979.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 451,
@@ -4059,7 +4059,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/first-take-deluxe-edition\/1553542062",
             "appleMusicID": "1553542062",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-451-Roberta-Flack-First-Take.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/21\/92\/92\/21929237-dc83-f6a8-05ff-d2808530e226\/603497844142.jpg\/600x600bb.jpg"
         },
         {
             "rank": 452,
@@ -4068,7 +4068,7 @@
             "year": 1974,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/anthology\/1434895644",
             "appleMusicID": "1434895644",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-452-Diana-Ross-and-the-Supremes-Anthology.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/9d\/60\/27\/9d6027cb-4923-4b3f-3bf5-55fd73de7ea6\/06UMGIM14781.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 453,
@@ -4077,7 +4077,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/pretty-hate-machine-remastered\/1440940694",
             "appleMusicID": "1440940694",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-453-Nine-Inch-Nails-Pretty-Hate-Machine.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/df\/cf\/84\/dfcf8463-e753-5891-20d6-824749d220ca\/00859704670275.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 454,
@@ -4086,7 +4086,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ege-bamyasi-remastered\/1675998345",
             "appleMusicID": "1675998345",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-454-Can-Ege-Bamyasi.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/be\/3e\/45\/be3e4587-a9ae-9ca4-5aae-daa16b3a00f9\/cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 455,
@@ -4095,7 +4095,7 @@
             "year": 1958,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/go-bo-diddley\/1449758009",
             "appleMusicID": "1449758009",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-455-Bo-diddley-Bo-Diddley-AND-Go-Bo-Diddley.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/87\/85\/5b\/87855be9-6dcd-11f0-6471-75ccee186008\/00602577174476.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 456,
@@ -4104,7 +4104,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/greatest-hits\/1203896404",
             "appleMusicID": "1203896404",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-456-Al-Green-Greatest-Hits.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/c0\/90\/63\/c0906357-b17c-bfcc-30c8-0532c52d8d0d\/886446283692.jpg\/600x600bb.jpg"
         },
         {
             "rank": 457,
@@ -4113,7 +4113,7 @@
             "year": 1990,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/i-do-not-want-what-i-havent-got\/1629185300",
             "appleMusicID": "1629185300",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-457-Sinead-OConnor-I-Do-Now-Want-What-I-Havent-Got.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/76\/43\/92\/764392cc-de5e-eadd-8ccc-ba0e3ec04401\/5054526647565.png\/600x600bb.jpg"
         },
         {
             "rank": 458,
@@ -4122,7 +4122,7 @@
             "year": 2013,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/southeastern-10-year-anniversary-edition\/1704740898",
             "appleMusicID": "1704740898",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-458-Jason-Isbell-Southeastern.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/29\/c1\/6e\/29c16ef6-3a5b-82e2-e617-a1d709a207d4\/197189766855.jpg\/600x600bb.jpg"
         },
         {
             "rank": 459,
@@ -4131,7 +4131,7 @@
             "year": 2009,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/man-on-the-moon-the-end-of-day-expanded-version\/1445846640",
             "appleMusicID": "1445846640",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-459-Kid-Cudi-Man-of-the-Moon.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/62\/5c\/ed\/625ced7f-53ac-f83d-7011-7bfb4b7a22a2\/00602527201900.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 460,
@@ -4140,7 +4140,7 @@
             "year": 2017,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/melodrama\/1429662346",
             "appleMusicID": "1429662346",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-460-Lorde-Melodrama.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/8d\/0d\/15\/8d0d1532-493b-52ec-6a29-a239ced6931b\/17UMGIM81023.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 461,
@@ -4149,7 +4149,7 @@
             "year": 2008,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/for-emma-forever-ago\/1016407094",
             "appleMusicID": "1016407094",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-461-Bon-Iver-For-Emma.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/fd\/50\/05\/fd500585-b975-2f0c-8279-a8ad41644ec2\/652637280906.png\/600x600bb.jpg"
         },
         {
             "rank": 462,
@@ -4158,7 +4158,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-gilded-palace-of-sin\/1440876015",
             "appleMusicID": "1440876015",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-462-Flying-Burrito-Brothers-The-Gilded-Palace-of-Sin.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/58\/64\/dc\/5864dce6-9575-b3f3-baa3-e4873598130a\/00602567246824.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 463,
@@ -4167,7 +4167,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/eli-and-the-thirteenth-confessi\u00f3n-expanded-edition\/273493406",
             "appleMusicID": "273493406",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-463-Laura-Nyro-Eli-The-13th-Confession.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/2a\/88\/60\/mzi.whhtofcb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 464,
@@ -4176,7 +4176,7 @@
             "year": 1973,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/3-3\/1030452445",
             "appleMusicID": "1030452445",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-464-Isley-Brothers-3x3-1.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/7e\/1a\/2f\/7e1a2f9c-154a-49d0-0484-44550a26da26\/mzm.fckxoqtz.jpg\/600x600bb.jpg"
         },
         {
             "rank": 465,
@@ -4185,7 +4185,7 @@
             "year": 2003,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-best-of-the-classic-years\/1587789326",
             "appleMusicID": "1587789326",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-465-King-Sunny-Ade-Best-of-the-Classic-Years.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/57\/6f\/d1\/576fd1d2-3318-645e-0376-2ce2370dae38\/016351663429_Cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 466,
@@ -4194,7 +4194,7 @@
             "year": 1981,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/red\/1443089159",
             "appleMusicID": "1443089159",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2023\/12\/Black-Uhuru-red-1.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/66\/aa\/95\/66aa95a7-f047-68af-ce94-444b0b4fef8b\/00044006362922.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 467,
@@ -4203,7 +4203,7 @@
             "year": 2009,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/blacksummersnight-2009\/319362174",
             "appleMusicID": "319362174",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-467-Maxwell-Black-Summers-Night.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/e4\/a3\/d4\/e4a3d458-a1c2-b14c-568f-f8a8503c022d\/884977106770.jpg\/600x600bb.jpg"
         },
         {
             "rank": 468,
@@ -4212,7 +4212,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/some-girls-remastered-2011\/1440816775",
             "appleMusicID": "1440816775",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-468-The-Rolling-Stones-Some-Girls.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/d9\/6d\/64\/d96d6477-52a7-2f7e-dcb3-64ca658e9da5\/08UMGIM15738.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 469,
@@ -4221,7 +4221,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/clandestino\/725493481",
             "appleMusicID": "725493481",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-469-Manu-Chao-Clandestino.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/04\/ab\/09\/04ab09c9-5355-8ae2-cf95-221baf5c4758\/5060281616937_cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 470,
@@ -4230,7 +4230,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/400-degreez\/1440644146",
             "appleMusicID": "1440644146",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-470-Juvenile-400-Degreez.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/0c\/c9\/2e\/0cc92e6a-789e-3116-095e-5071f778bfee\/06UMGIM04297.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 471,
@@ -4239,7 +4239,7 @@
             "year": 1967,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/surrealistic-pillow-2003-bonus-track-edition\/281811707",
             "appleMusicID": "281811707",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-471-Jefferson-Airplane-Surrealistic-Pillow.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/5c\/bd\/17\/5cbd17d6-ceea-e185-e889-ee494cc650da\/828765035125.jpg\/600x600bb.jpg"
         },
         {
             "rank": 472,
@@ -4248,7 +4248,7 @@
             "year": 2017,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ctrl-deluxe\/1628387909",
             "appleMusicID": "1628387909",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-472-SZA-Ctrl.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/cd\/c7\/05\/cdc7052e-dbd1-d302-adc2-064dc78db743\/196589231000.jpg\/600x600bb.jpg"
         },
         {
             "rank": 473,
@@ -4257,7 +4257,7 @@
             "year": 2004,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/barrio-fino-bonus-track-version\/1586112407",
             "appleMusicID": "1586112407",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-473-Daddy-Yankee-Barrio-Fino.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/51\/15\/58\/51155831-8fca-dade-fa15-9c0ef2b67cdb\/191773528348_cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 474,
@@ -4266,7 +4266,7 @@
             "year": 1972,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/1-record\/1422691834",
             "appleMusicID": "1422691834",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-474-Big-Star-1-Record.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/85\/37\/51\/85375198-43fe-4ab2-aa64-7c33e62f4df8\/00888072359536.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 475,
@@ -4275,7 +4275,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/sheryl-crow\/1440918672",
             "appleMusicID": "1440918672",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-475-sheryl-crow-sheryl-crow.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/79\/10\/f1\/7910f114-a452-62ca-99a0-7ccc78b80c2b\/06UMGIM59872.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 476,
@@ -4284,7 +4284,7 @@
             "year": 1974,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/kimono-my-house-21st-century-edition\/1443750483",
             "appleMusicID": "1443750483",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-476-Kimono-My-House.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/57\/ed\/36\/57ed368e-b28f-6641-3f78-e737bf3b2d18\/00602517912779.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 477,
@@ -4293,7 +4293,7 @@
             "year": 1959,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/moanin-in-the-moonlight\/1425203542",
             "appleMusicID": "1425203542",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-477-Howlin-Wolf-Moanin-in-the-Moonlight.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/b2\/ed\/5e\/b2ed5ea1-2bc0-5b3a-8297-7df5ed2d13b8\/15UMGIM29010.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 478,
@@ -4302,7 +4302,7 @@
             "year": 1968,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/something-else-by-the-kinks\/1361968256",
             "appleMusicID": "1361968256",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-478-Kinks-Something-else-by-the-kinks.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/4a\/b4\/8d\/4ab48d02-a6ee-9784-4cfd-77f7308bf439\/5414939542374.jpg\/600x600bb.jpg"
         },
         {
             "rank": 479,
@@ -4311,7 +4311,7 @@
             "year": 1994,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/amor-prohibido\/1440860107",
             "appleMusicID": "1440860107",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-479-Selena-Amor-Prohibido.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music118\/v4\/e4\/88\/52\/e48852d5-a4c6-9714-d36b-776930b30b28\/5054526758650_1.jpg\/600x600bb.jpg"
         },
         {
             "rank": 480,
@@ -4320,7 +4320,7 @@
             "year": 2016,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-weight-of-these-wings\/1166241178",
             "appleMusicID": "1166241178",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-480-Miranda-Lambert-Weight-of-These-Wings.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/e5\/98\/16\/e5981609-03e2-e4fa-7862-59fcb129d961\/886446177656.jpg\/600x600bb.jpg"
         },
         {
             "rank": 481,
@@ -4329,7 +4329,7 @@
             "year": 1996,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/if-youre-feeling-sinister\/516530926",
             "appleMusicID": "516530926",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-481-Belle-and-Sebastian-If-Youre-Feeling-Sinister.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/v4\/7d\/63\/e6\/7d63e620-bfa3-173c-d82e-b564b11fd18b\/cover.jpg\/600x600bb.jpg"
         },
         {
             "rank": 482,
@@ -4338,7 +4338,7 @@
             "year": 1992,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/bizarre-ride-ii-the-pharcyde-25th-anniversary-edition\/1440946475",
             "appleMusicID": "1440946475",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-482-Tha-Pharcyde-Bizarre-Ride-II-Tha-Pharcyde.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/ac\/78\/b2\/ac78b2be-b4de-7cd3-1861-1126d743e795\/00888072035454.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 483,
@@ -4347,7 +4347,7 @@
             "year": 2001,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-483-muddy-waters-the-anthology.jpg"
+            "imageURL": null
         },
         {
             "rank": 484,
@@ -4356,7 +4356,7 @@
             "year": 2011,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/born-this-way\/1440824019",
             "appleMusicID": "1440824019",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-484-Lady-Gaga-Born-This-Way.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/65\/1b\/f6\/651bf621-fcf2-e3ba-4ef4-22645f26e0a0\/11UMGIM12477.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 485,
@@ -4365,7 +4365,7 @@
             "year": 1974,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/i-want-to-see-the-bright-lights\/1529524217",
             "appleMusicID": "1529524217",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-485-Richard-and-Linda-Thompson-I-Want-to-See-the-bright-lights-tonight.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/a7\/02\/c4\/a702c4dc-832b-219a-d86e-0d3d3892ae50\/20UMGIM10457.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 486,
@@ -4374,7 +4374,7 @@
             "year": 2006,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/continuum\/184335550",
             "appleMusicID": "184335550",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-486-john-mayer-continuum-x.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/7a\/a0\/f4\/7aa0f487-f983-390e-73ef-005115eea1e0\/dj.oqpplyfm.jpg\/600x600bb.jpg"
         },
         {
             "rank": 487,
@@ -4383,7 +4383,7 @@
             "year": 1981,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/damaged\/117018235",
             "appleMusicID": "117018235",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-487-Black-Flag-Damaged.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/ff\/2b\/6e\/ff2b6ede-cc24-ae84-6dce-627abb57c32d\/mzi.nbdppaza.tif\/600x600bb.jpg"
         },
         {
             "rank": 488,
@@ -4392,7 +4392,7 @@
             "year": 1969,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-stooges\/393789238",
             "appleMusicID": "393789238",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-488-The-Stooges-The-Stooges.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/41\/19\/3b\/41193bb2-ffc4-043f-4ddd-128c272d8f82\/mzi.qimpmkxb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 489,
@@ -4401,7 +4401,7 @@
             "year": 1991,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-489-Phil-Spector-Various-Artists-Back-to-Mono.jpg"
+            "imageURL": null
         },
         {
             "rank": 490,
@@ -4410,7 +4410,7 @@
             "year": 1975,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/heart-like-a-wheel-2013-remaster\/1440872195",
             "appleMusicID": "1440872195",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-490-Linda-Ronstadt-Heart-Like-a-Wheel.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/61\/c6\/88\/61c68877-6273-7dd8-748d-942e1c0e35e2\/00602537554676.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 491,
@@ -4419,7 +4419,7 @@
             "year": 2022,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/harrys-house\/1615584999",
             "appleMusicID": "1615584999",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2022\/11\/HarryStylesHarrysHouse.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/2a\/19\/fb\/2a19fb85-2f70-9e44-f2a9-82abe679b88e\/886449990061.jpg\/600x600bb.jpg"
         },
         {
             "rank": 492,
@@ -4428,7 +4428,7 @@
             "year": 1989,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/nick-of-time\/715516713",
             "appleMusicID": "715516713",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-492-Bonnie-Raitt-Nick-of-Time.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/27\/62\/21\/276221c4-ce64-af14-4ab1-0d95ba02852b\/00094634106153.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 493,
@@ -4437,7 +4437,7 @@
             "year": 1978,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/here-my-dear\/1440850217",
             "appleMusicID": "1440850217",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-493-Marvin-Gaye-Here-My-Dear.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/bc\/ae\/e3\/bcaee340-68a6-2eba-16c0-be55f78c1ba0\/00602547135636.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 494,
@@ -4446,7 +4446,7 @@
             "year": 1964,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/presenting-the-fabulous-ronettes-featuring-veronica\/518081279",
             "appleMusicID": "518081279",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-494-THE-RONETTEs-Presenting-the-Fabulous-Ronettes.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/17\/05\/50\/17055031-c0c1-7e73-42d9-5e3517236f02\/886443431355.jpg\/600x600bb.jpg"
         },
         {
             "rank": 495,
@@ -4455,7 +4455,7 @@
             "year": 1991,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ii\/1440911985",
             "appleMusicID": "1440911985",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-495-Boyz-II-Men-II.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/55\/43\/32\/5543322e-bfa4-9402-4edb-bd8192c75eff\/06UMGIM32384.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 496,
@@ -4464,7 +4464,7 @@
             "year": 1998,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/d\u00f3nde-est\u00e1n-los-ladrones\/192682818",
             "appleMusicID": "192682818",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-496-Shakira-Donde-Estan-los-Ladrones.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/e5\/6d\/96\/e56d9688-0239-7c8f-f907-7614c0f9860b\/mzi.uffuznlo.jpg\/600x600bb.jpg"
         },
         {
             "rank": 497,
@@ -4473,7 +4473,7 @@
             "year": 1985,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/the-indestructible-beat-of-soweto-volume-one\/208459678",
             "appleMusicID": "208459678",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-497-Indestructible-Beat-of-Soweto.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/7b\/2f\/f5\/7b2ff5f8-1be8-dab1-d14d-dbba6aa2a1b9\/mzi.eyyosidi.jpg\/600x600bb.jpg"
         },
         {
             "rank": 498,
@@ -4482,7 +4482,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/suicide-2019-remaster\/1463179848",
             "appleMusicID": "1463179848",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-498-Suicide-Suicide.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/87\/9c\/62\/879c621f-6c35-e07f-9556-995b5bd7e02d\/4050538514346.jpg\/600x600bb.jpg"
         },
         {
             "rank": 499,
@@ -4491,7 +4491,7 @@
             "year": 1977,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/ask-rufus\/1443809905",
             "appleMusicID": "1443809905",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-499-Ask-Rufus-Rufus-Chaka-Khan.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/a7\/26\/a3\/a726a356-0b6b-5653-8293-9187a3772859\/00008811044923.rgb.jpg\/600x600bb.jpg"
         },
         {
             "rank": 500,
@@ -4500,7 +4500,7 @@
             "year": 2004,
             "appleMusicURL": "https:\/\/music.apple.com\/album\/funeral\/1249417623",
             "appleMusicID": "1249417623",
-            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-500-Arcade-Fire-Funeral.jpg"
+            "imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/2b\/09\/6e\/2b096e8c-ae65-fc42-a4b1-19abb4100433\/886446576442.jpg\/600x600bb.jpg"
         }
     ]
 }

--- a/data/collections/RS500.json
+++ b/data/collections/RS500.json
@@ -1,5 +1,5 @@
 {
-    "name": "Rolling Stone Top 500",
+    "name": "Rolling Stone: Greatest Albums",
     "article_url": "https:\/\/www.rollingstone.com\/music\/music-lists\/best-albums-of-all-time-1062063\/",
     "albums": [
         {
@@ -486,7 +486,7 @@
             "year": 1991,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": null
+            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-054-James-Brown-Star-Time.jpg"
         },
         {
             "rank": 55,
@@ -702,7 +702,7 @@
             "year": 1976,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": null
+            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-078-Elvis-Presley.-The-Sun-Sessions.jpg"
         },
         {
             "rank": 79,
@@ -1773,7 +1773,7 @@
             "year": 1964,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": null
+            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-197-The-Beatles-Meet-The-Beatles.jpg"
         },
         {
             "rank": 198,
@@ -2925,7 +2925,7 @@
             "year": 1993,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": null
+            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-325-Jerry-Lee-Lewis-All-Killer-No-Filler.jpg"
         },
         {
             "rank": 326,
@@ -3339,7 +3339,7 @@
             "year": 1973,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": null
+            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-371-The-Temptations-Anthology.jpg"
         },
         {
             "rank": 372,
@@ -4347,7 +4347,7 @@
             "year": 2001,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": null
+            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-483-muddy-waters-the-anthology.jpg"
         },
         {
             "rank": 484,
@@ -4401,7 +4401,7 @@
             "year": 1991,
             "appleMusicURL": null,
             "appleMusicID": null,
-            "imageURL": null
+            "imageURL": "https:\/\/www.rollingstone.com\/wp-content\/uploads\/2020\/09\/R1344-489-Phil-Spector-Various-Artists-Back-to-Mono.jpg"
         },
         {
             "rank": 490,

--- a/data/collections/RS50CO.json
+++ b/data/collections/RS50CO.json
@@ -1,0 +1,456 @@
+{
+	"name": "Billboard: The 50 Greatest Concept Albums of All Time",
+	"article_url": "https:\/\/www.rollingstone.com\/music\/music-lists\/best-concept-albums-1234604040\/the-roots-20-1234604517\/",
+	"albums": [
+		{
+			"rank": 1,
+			"artist": "Kendrick Lamar",
+			"album": "good kid, m.A.A.d city",
+			"year": 2012,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/good-kid-m-a-a-d-city-deluxe\/1440873524",
+			"appleMusicID": "1440873524",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/ba\/c3\/c5\/bac3c531-dc7e-d0da-d785-fe9f17219950\/12UMGIM52990.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 2,
+			"artist": "Green Day",
+			"album": "American Idiot",
+			"year": 2004,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/american-idiot-deluxe-edition\/207192731",
+			"appleMusicID": "207192731",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/9e\/17\/c2\/mzi.ofggkufy.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 3,
+			"artist": "Pink Floyd",
+			"album": "The Wall",
+			"year": 1979,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/the-wall\/704273346",
+			"appleMusicID": "704273346",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Features124\/v4\/aa\/88\/2c\/aa882ccd-d153-9901-8ee1-c246e5b704b3\/dj.esjczuop.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 4,
+			"artist": "Raekwon",
+			"album": "Only Built 4 Cuban Linx \u2026",
+			"year": 1995,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/only-built-4-cuban-linx\/258634938",
+			"appleMusicID": "258634938",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/e1\/b1\/de\/e1b1de50-cca7-28d1-9e40-00c2251ead3d\/078636666327.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 5,
+			"artist": "The Who",
+			"album": "Tommy",
+			"year": 1969,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/tommy\/1461210985",
+			"appleMusicID": "1461210985",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/f3\/22\/7f\/f3227fd3-758e-2728-7db2-25b29373c8ae\/18UMGIM35635.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 6,
+			"artist": "Liz Phair",
+			"album": "Exile in Guyville",
+			"year": 1993,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/exile-in-guyville-2018-remaster\/1589236833",
+			"appleMusicID": "1589236833",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/f0\/96\/e6\/f096e697-a41a-2ec3-e48e-754b4f85aada\/744861111450.png\/600x600bb.jpg"
+		},
+		{
+			"rank": 7,
+			"artist": "Rush",
+			"album": "2112",
+			"year": 1976,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/2112-remastered\/1445876680",
+			"appleMusicID": "1445876680",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/a4\/44\/e5\/a444e517-39be-02b3-32c9-c45d6b1bd3e9\/00602527893372.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 8,
+			"artist": "My Chemical Romance",
+			"album": "The Black Parade",
+			"year": 2006,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/the-black-parade\/1156310650",
+			"appleMusicID": "1156310650",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/56\/99\/8a\/56998a1c-efe7-fdf0-2b1d-e2da88d8df52\/093624917724.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 9,
+			"artist": "Frank Sinatra",
+			"album": "In the Wee Small Hours",
+			"year": 1955,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/in-the-wee-small-hours\/1440815019",
+			"appleMusicID": "1440815019",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/97\/a7\/42\/97a7424f-8161-052f-ce3c-93730c2d30de\/14UMGIM32540.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 10,
+			"artist": "Rosal\u00eda",
+			"album": "El Mal Querer",
+			"year": 2018,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/el-mal-querer\/1436309944",
+			"appleMusicID": "1436309944",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/2c\/55\/e1\/2c55e13f-15d8-1c7c-1826-c5fa55deaa8f\/886447217139.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 11,
+			"artist": "The Beatles",
+			"album": "Sgt. Pepper's Lonely Hearts Club Band",
+			"year": 1967,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/sgt-peppers-lonely-hearts-club-band-remix\/1573250333",
+			"appleMusicID": "1573250333",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/64\/85\/d2\/6485d219-91ac-5481-2668-7eab1320436d\/21UMGIM57007.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 12,
+			"artist": "Janelle Mon\u00e1e",
+			"album": "The ArchAndroid",
+			"year": 2010,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/the-archandroid-deluxe-version\/382079530",
+			"appleMusicID": "382079530",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/14\/b4\/c3\/mzi.riqvytaj.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 13,
+			"artist": "David Bowie",
+			"album": "The Rise and Fall of Ziggy Stardust and the Spiders From Mars",
+			"year": 1972,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/the-rise-and-fall-of-ziggy-stardust-and-the\/1039796877",
+			"appleMusicID": "1039796877",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/5f\/fa\/56\/5ffa56c2-ea1f-7a17-6bad-192ff9b6476d\/825646124206.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 14,
+			"artist": "Radiohead",
+			"album": "Kid A",
+			"year": 2000,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/kid-a\/1097862870",
+			"appleMusicID": "1097862870",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music122\/v4\/bd\/8e\/13\/bd8e1358-b367-a689-cb84-cebd0b067dc4\/634904078263.png\/600x600bb.jpg"
+		},
+		{
+			"rank": 15,
+			"artist": "Beyonc\u00e9",
+			"album": "Lemonade",
+			"year": 2016,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/lemonade\/1460430561",
+			"appleMusicID": "1460430561",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/db\/25\/a1\/db25a1c0-8a4a-3b4d-226d-7c7704dc92da\/886447680711.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 16,
+			"artist": "Sly and the Family Stone",
+			"album": "There\u2019s a Riot Goin\u2019 On",
+			"year": 1971,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/theres-a-riot-goin-on-expanded-edition\/216546634",
+			"appleMusicID": "216546634",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/91\/01\/9f\/91019f68-fbc9-5620-d49a-88043d75371e\/828767591124.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 17,
+			"artist": "Jackson Browne",
+			"album": "Running On Empty",
+			"year": 1977,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/running-on-empty-remastered\/1466749581",
+			"appleMusicID": "1466749581",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/95\/f7\/f3\/95f7f3a3-d793-fb71-572d-4dbd686e5252\/603497851195.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 18,
+			"artist": "The Who",
+			"album": "Quadrophenia",
+			"year": 1973,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/quadrophenia-2013-remaster\/1440824353",
+			"appleMusicID": "1440824353",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/cc\/86\/10\/cc861044-0537-0de4-4389-dceec0c13b96\/06UMGIM44799.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 19,
+			"artist": "Marvin Gaye",
+			"album": "What's Going On",
+			"year": 1971,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/whats-going-on\/1538081586",
+			"appleMusicID": "1538081586",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/76\/36\/2d\/76362d74-cb7a-8ef9-104e-cde1d858e9a9\/20UMGIM95279.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 20,
+			"artist": "Janet Jackson",
+			"album": "Control",
+			"year": 1986,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/control\/1440831636",
+			"appleMusicID": "1440831636",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/ed\/b0\/20\/edb02000-b77f-22f4-6b7f-c46f62d4517c\/00602547592361.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 21,
+			"artist": "Brian Wilson",
+			"album": "Smile",
+			"year": 2004,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/smile\/29164695",
+			"appleMusicID": "29164695",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music\/y2004\/m11\/d09\/h00\/s06.ceiowlmw.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 22,
+			"artist": "Donna Summer",
+			"album": "Once Upon a Time...",
+			"year": 1977,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/once-upon-a-time\/1440861081",
+			"appleMusicID": "1440861081",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/64\/a1\/fe\/64a1fe5f-762f-e3e5-88c6-146ffb49b3d9\/06UMGIM01762.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 23,
+			"artist": "Genesis",
+			"album": "The Lamb Lies Down on Broadway",
+			"year": 1974,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/the-lamb-lies-down-on-broadway-2007-stereo-mix\/358933158",
+			"appleMusicID": "358933158",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/44\/1d\/e7\/441de7e6-4e8d-9739-0a94-dc6013263620\/mzi.vkykexny.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 24,
+			"artist": "Randy Newman",
+			"album": "Good Old Boys",
+			"year": 1974,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/good-old-boys-deluxe\/750173801",
+			"appleMusicID": "750173801",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/99\/92\/bc\/9992bca7-ffe9-ec48-e30a-6a2e562ce422\/081227383923.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 25,
+			"artist": "BTS",
+			"album": "Map of the Soul: 7",
+			"year": 2020,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/map-of-the-soul-7\/1599362484",
+			"appleMusicID": "1599362484",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/bd\/68\/9b\/bd689bf2-ef25-4973-7ecd-7eb4965019c5\/195081034713_Cover.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 26,
+			"artist": "Willie Nelson",
+			"album": "Red Headed Stranger",
+			"year": 1975,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/red-headed-stranger\/404365971",
+			"appleMusicID": "404365971",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music123\/v4\/88\/d6\/67\/88d6676e-67ce-f907-d4fe-eae50f805f63\/074643348225.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 27,
+			"artist": "H\u00fcsker D\u00fc",
+			"album": "Zen Arcade",
+			"year": 1984,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/zen-arcade\/515427828",
+			"appleMusicID": "515427828",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/a4\/6e\/e2\/a46ee2c0-5082-5ff9-31bf-3aba75ea7e29\/dj.ewnapbia.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 28,
+			"artist": "The Kinks",
+			"album": "The Kinks Are the Village Green Preservation Society",
+			"year": 1968,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/the-kinks-are-the-village-green-preservation-society\/1422691058",
+			"appleMusicID": "1422691058",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/3e\/a3\/f4\/3ea3f4f0-2d52-6c45-75ae-880055383a48\/4050538402223.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 29,
+			"artist": "Jazmine Sullivan",
+			"album": "Heaux Tales",
+			"year": 2021,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/heaux-tales\/1549719545",
+			"appleMusicID": "1549719545",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/e6\/1e\/43\/e61e43e4-a8c9-2ddd-04f8-89df5515eadd\/886448974314.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 30,
+			"artist": "Marvin Gaye",
+			"album": "Here, My Dear",
+			"year": 1978,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/here-my-dear\/1440850217",
+			"appleMusicID": "1440850217",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/bc\/ae\/e3\/bcaee340-68a6-2eba-16c0-be55f78c1ba0\/00602547135636.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 31,
+			"artist": "Nick Cave and the Bad Seeds",
+			"album": "Ghosteen",
+			"year": 2019,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/ghosteen\/1479214340",
+			"appleMusicID": "1479214340",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/13\/54\/56\/135456fb-4061-84ad-f75a-90ec8b0bc612\/5056167114802_1.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 32,
+			"artist": "Millie Jackson",
+			"album": "Caught Up",
+			"year": 1974,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/caught-up\/1621385119",
+			"appleMusicID": "1621385119",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/03\/99\/d4\/0399d404-fc54-089c-6ba5-f6858d83c2f1\/29667806787.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 33,
+			"artist": "Parliament",
+			"album": "Funkentelechy vs. the Placebo Syndrome",
+			"year": 1977,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/funkentelechy-vs-the-placebo-syndrome\/1434913911",
+			"appleMusicID": "1434913911",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/15\/68\/31\/15683110-5d60-1a2a-e196-18be48cf5c30\/00602567825920.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 34,
+			"artist": "Iron Maiden",
+			"album": "Seventh Son of a Seventh Son",
+			"year": 1988,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/seventh-son-of-a-seventh-son\/979945054",
+			"appleMusicID": "979945054",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/24\/cf\/d7\/24cfd71d-d45a-ded4-85f7-8bb9ec5e4489\/825646129164.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 35,
+			"artist": "The Magnetic Fields",
+			"album": "69 Love Songs",
+			"year": 1999,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/69-love-songs\/15224879",
+			"appleMusicID": "15224879",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/fb\/9a\/9a\/fb9a9ac4-516b-1242-0f59-55dbb39f60c5\/169_MagFields_69LS_2500px.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 36,
+			"artist": "Raphael Saadiq",
+			"album": "Jimmy Lee",
+			"year": 2019,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/jimmy-lee\/1465332884",
+			"appleMusicID": "1465332884",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/ba\/c0\/bc\/bac0bc62-b4d6-4f68-a7de-23a26a14ed04\/886447713822.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 37,
+			"artist": "Alice Cooper",
+			"album": "Welcome To My Nightmare",
+			"year": 1975,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/welcome-to-my-nightmare\/355055007",
+			"appleMusicID": "355055007",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/c7\/b9\/d1\/c7b9d142-85db-6bae-97fa-471c5c8da2c6\/075678154263.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 38,
+			"artist": "The Mountain Goats",
+			"album": "Tallahassee",
+			"year": 2002,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/tallahassee\/310998170",
+			"appleMusicID": "310998170",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/cc\/e1\/75\/cce175c1-b3a0-2cab-44c5-fd415d5fa7de\/652637221589.png\/600x600bb.jpg"
+		},
+		{
+			"rank": 39,
+			"artist": "Toni Braxton & Babyface",
+			"album": "Love, Marriage & Divorce",
+			"year": 2014,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/love-marriage-divorce\/1440871049",
+			"appleMusicID": "1440871049",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/12\/dd\/bd\/12ddbd4e-c376-1ad5-861e-687286534338\/13UAEIM26467.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 40,
+			"artist": "The Hold Steady",
+			"album": "Separation Sunday",
+			"year": 2005,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/separation-sunday\/1675991625",
+			"appleMusicID": "1675991625",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/e5\/4f\/dc\/e54fdc39-8acb-f488-fec8-4393e343ca54\/cover.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 41,
+			"artist": "Elton John",
+			"album": "Captain Fantastic and the Brown Dirt Cowboy",
+			"year": 1975,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/captain-fantastic-and-the-brown-dirt-cowboy\/1440810893",
+			"appleMusicID": "1440810893",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music116\/v4\/83\/dc\/2a\/83dc2ad2-61eb-feb2-80df-e77206cc3dbc\/06UMGIM53454.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 42,
+			"artist": "Halsey",
+			"album": "If I Can\u2019t Have Love, I Want Power",
+			"year": 2021,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/if-i-cant-have-love-i-want-power-deluxe\/1642385548",
+			"appleMusicID": "1642385548",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music112\/v4\/1c\/d5\/40\/1cd5401d-1dd4-3dbc-2750-f618672bb1f2\/21UMGIM35852.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 43,
+			"artist": "J Balvin",
+			"album": "Colores",
+			"year": 2020,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/colores\/1500490683",
+			"appleMusicID": "1500490683",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music125\/v4\/ae\/b3\/66\/aeb36667-f9b2-c455-c3fc-a53bbd5ec4c1\/20UMGIM10542.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 44,
+			"artist": "Drive-By Truckers",
+			"album": "Southern Rock Opera",
+			"year": 2001,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/southern-rock-opera\/1452800570",
+			"appleMusicID": "1452800570",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music114\/v4\/25\/89\/33\/2589338d-242d-94aa-232c-88e189d0c23d\/00008817030821.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 45,
+			"artist": "Queensr\u00ffche",
+			"album": "Operation: Mindcrime",
+			"year": 1988,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/operation-mindcrime-deluxe-edition\/715912112",
+			"appleMusicID": "715912112",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/77\/da\/93\/77da938b-dd52-0ca6-8bbe-5e831394c865\/00094636012858.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 46,
+			"artist": "Marina and the Diamonds",
+			"album": "Electra Heart",
+			"year": 2012,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/electra-heart-deluxe-video-version\/612476580",
+			"appleMusicID": "612476580",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music115\/v4\/a3\/d0\/87\/a3d08708-9087-e238-9fa3-e09caa196f54\/5053105215522.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 47,
+			"artist": "The Avalanches",
+			"album": "Since I Left You",
+			"year": 2001,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/since-i-left-you-20th-anniversary-deluxe-edition\/1559888850",
+			"appleMusicID": "1559888850",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music126\/v4\/1b\/1c\/b1\/1b1cb10e-0292-1d9c-1977-719aae824f29\/191404116456.png\/600x600bb.jpg"
+		},
+		{
+			"rank": 48,
+			"artist": "XTC",
+			"album": "Skylarking",
+			"year": 1986,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/skylarking-remastered\/1440889477",
+			"appleMusicID": "1440889477",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music128\/v4\/68\/60\/36\/686036d4-baf9-ac17-e70a-54589a5ab24b\/00602557412673.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 49,
+			"artist": "The Roots",
+			"album": "Undun",
+			"year": 2011,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/undun\/1440805652",
+			"appleMusicID": "1440805652",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music113\/v4\/51\/bd\/bd\/51bdbda4-8f8a-ed08-d402-6395fcb2bac6\/11UMGIM38405.rgb.jpg\/600x600bb.jpg"
+		},
+		{
+			"rank": 50,
+			"artist": "Styx",
+			"album": "Kilroy Was Here",
+			"year": 1983,
+			"appleMusicURL": "https:\/\/music.apple.com\/album\/kilroy-was-here\/1440714769",
+			"appleMusicID": "1440714769",
+			"imageURL": "https:\/\/is1-ssl.mzstatic.com\/image\/thumb\/Music124\/v4\/da\/75\/bd\/da75bd7e-c8cc-d98a-c895-f35a58b53857\/06UMGIM01285.rgb.jpg\/600x600bb.jpg"
+		}
+	]
+}

--- a/data/collections/RS50CO.json
+++ b/data/collections/RS50CO.json
@@ -1,6 +1,6 @@
 {
-	"name": "Billboard: The 50 Greatest Concept Albums of All Time",
-	"article_url": "https:\/\/www.rollingstone.com\/music\/music-lists\/best-concept-albums-1234604040\/the-roots-20-1234604517\/",
+	"name": "Rolling Stone: Concept Albums",
+	"article_url": "https:\/\/www.rollingstone.com\/music\/music-lists\/best-concept-albums-1234604040",
 	"albums": [
 		{
 			"rank": 1,


### PR DESCRIPTION
- Swapped image URLs for Rolling Stone Greatest Albums from Rolling Stone server to Apple server
- Added Rolling Stone Concept Albums collection
- Made sure that there would be no regression regarding the Apple Music IDs in RS500.json